### PR TITLE
Clean up markdown documentation

### DIFF
--- a/AGENT_GUIDE.md
+++ b/AGENT_GUIDE.md
@@ -1,0 +1,71 @@
+# Agent Guide 🤖
+
+> **Scope** These rules apply to any automated contributor (Jules, GitHub Copilot, OpenAI Codex, etc.).
+> Humans should follow the standard CONTRIBUTING.md.
+
+## 1 Auth & Identity
+
+* **Git user.email** must contain the agent name (e.g., `jules-bot@gymgenius.ai`).
+* Each commit must add the trailer `Signed-off-by: Agent <agent@domain>`.
+
+## 2 Branch & PR Protocol
+
+| Rule | Example |
+|------|---------|
+| Branch name | `<task-ID>/<agent>` → `P1-BE-001/jules` |
+| Base branch | always `main` |
+| PR title | `[P1-BE-001] Describe action` |
+| Max LOC per PR | **400** changed lines |
+| CI status | must be green (`lint`, `test`, `docker-build`) |
+
+## 3 Coding Rules
+
+* Run `make lint` → eslint/prettier must pass.
+* Generate code **inside the correct workspace path**; never touch `/node_modules`.
+* Follow folder mapping from `ARCHITECTURE.md` JSON.
+* All TypeScript must use `strict` mode; all Python must pass `ruff` linter.
+* If updating schema, also run `pnpm db:migrate:dev` and commit the SQL migration.
+
+## 4 Commit Message Convention
+
+```
+<type>(<scope>): <summary>  # type = feat | fix | refactor | chore | test
+
+Body: *optional*, wrap at 72 chars.
+Footer: “refs #<issue>” or “closes #<issue>”.
+```
+
+* Agents **must** include the task-ID in `<scope>` (e.g., `feat(api): P1-BE-001 add /v1/predict`).
+
+## 5 Safety & Guardrails
+
+* **NEVER** expose secrets—use `.env.example` keys only.
+* Load jumps: algorithm code must cap any single weight change to ±7.5 %.
+* Schema updates require a data-migration script or must be backward-compatible.
+* If CI warns “large diff” (> 400 LOC) → split into smaller PRs.
+
+## 6 Task Lifecycle (for planners)
+
+1. Agent reads open boxes in `ROADMAP.md`.
+2. Creates branch + draft PR with WIP prefix.
+3. Pushes commits, triggering CI.
+4. After green, removes WIP, assigns human reviewer.
+5. Merge when at least **one human** approves.
+
+## 7 Allowed & Forbidden Tools
+
+| Allowed | Forbidden |
+|---------|-----------|
+| `pnpm`, `docker`, `pytest`, `jest`, `ruff` | Direct DB writes in prod, `--force` git pushes to `main` |
+
+## 8 Self-Termination Clause
+
+If an agent detects an unresolvable merge conflict or CI red > 3 runs, it must:
+
+1. Post a comment tagging `@maintainers`.
+2. Close its own PR with status `blocked`.
+3. Await human intervention.
+
+---
+
+Happy coding 🤖

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,16 +1,6 @@
-Below are the **next two meta-docs**—ready to drop into the repo root.
-(If you’d rather get **CONTRIBUTING.md** and **LICENSE.md** now as well, just say the word.)
-
----
-
-## `ARCHITECTURE.md`
-
-````markdown
 # GymGenius — System Architecture
 
 > Last updated: 2025-06-14
-
----
 
 ## 1 Bird-Eye Diagram
 
@@ -36,9 +26,7 @@ flowchart LR
     B -- SQL --> E
     C -- SQL (read-only) --> E
     C -- store ckpt --> G
-````
-
----
+```
 
 ## 2 Service Registry (machine-readable)
 
@@ -84,8 +72,6 @@ flowchart LR
 
 Agents can parse this JSON to auto-map folder names to Docker services.
 
----
-
 ## 3 Data-Flow Cheat-Sheet
 
 | Path              | Payload                          | Notes                 |
@@ -97,8 +83,6 @@ Agents can parse this JSON to auto-map folder names to Docker services.
 | `engine → s3`     | `model-{date}.pth`               | Versioned checkpoints |
 | `api → postgres`  | CRUD                             | Prisma ORM            |
 
----
-
 ## 4 Key Tech Decisions (TDR links)
 
 * **Monorepo** (`pnpm workspace`) until MAU > 50 k → TDR-001
@@ -108,8 +92,6 @@ Agents can parse this JSON to auto-map folder names to Docker services.
 
 (TDR docs live in `docs/tdr/`.)
 
----
-
 ## 5 Runtime Envs
 
 | Environment | URL                             | Authentication   | Deploy Trigger      |
@@ -118,116 +100,10 @@ Agents can parse this JSON to auto-map folder names to Docker services.
 | Staging     | `https://staging.gymgenius.app` | Auth0 dev tenant | Merge → `main`      |
 | Production  | `https://app.gymgenius.app`     | Auth0 prod       | GitHub Release `v*` |
 
----
-
 ## 6 Scaling Plan
 
 1. **Vertical**: bump ECS task CPU/RAM (target P99 < 150 ms).
 2. **Read Replicas**: Postgres --> Aurora Serverless v2.
 3. **Service Split**: if `engine` CPU > 70 %, move to GPU node pool.
 
----
-
 *End of file*
-
-````
-
----
-
-## `AGENT_GUIDE.md`  *(rules for autonomous coding agents)*
-
-```markdown
-# Agent Guide 🤖
-
-> **Scope** These rules apply to any automated contributor (Jules, GitHub Copilot, OpenAI Codex, etc.).  
-> Humans should follow the standard CONTRIBUTING.md.
-
----
-
-## 1 Auth & Identity
-
-* **Git user.email** must contain the agent name (e.g., `jules-bot@gymgenius.ai`).  
-* Each commit must add the trailer `Signed-off-by: Agent <agent@domain>`.
-
----
-
-## 2 Branch & PR Protocol
-
-| Rule | Example |
-|------|---------|
-| Branch name | `<task-ID>/<agent>` → `P1-BE-001/jules` |
-| Base branch | always `main` |
-| PR title | `[P1-BE-001] Describe action` |
-| Max LOC per PR | **400** changed lines |
-| CI status | must be green (`lint`, `test`, `docker-build`) |
-
----
-
-## 3 Coding Rules
-
-* Run `make lint` → eslint/prettier must pass.  
-* Generate code **inside the correct workspace path**; never touch `/node_modules`.  
-* Follow folder mapping from `ARCHITECTURE.md` JSON.  
-* All TypeScript must use `strict` mode; all Python must pass `ruff` linter.  
-* If updating schema, also run `pnpm db:migrate:dev` and commit the SQL migration.
-
----
-
-## 4 Commit Message Convention
-
-````
-
-<type>(<scope>): <summary>  # type = feat | fix | refactor | chore | test
-
-Body: *optional*, wrap at 72 chars.
-Footer: “refs #<issue>” or “closes #<issue>”.
-
-```
-
-* Agents **must** include the task-ID in `<scope>` (e.g., `feat(api): P1-BE-001 add /v1/predict`).
-
----
-
-## 5 Safety & Guardrails
-
-* **NEVER** expose secrets—use `.env.example` keys only.  
-* Load jumps: algorithm code must cap any single weight change to ±7.5 %.  
-* Schema updates require a data-migration script or must be backward-compatible.  
-* If CI warns “large diff” (> 400 LOC) → split into smaller PRs.
-
----
-
-## 6 Task Lifecycle (for planners)
-
-1. Agent reads open boxes in `ROADMAP.md`.  
-2. Creates branch + draft PR with WIP prefix.  
-3. Pushes commits, triggering CI.  
-4. After green, removes WIP, assigns human reviewer.  
-5. Merge when at least **one human** approves.
-
----
-
-## 7 Allowed & Forbidden Tools
-
-| Allowed | Forbidden |
-|---------|-----------|
-| `pnpm`, `docker`, `pytest`, `jest`, `ruff` | Direct DB writes in prod, `--force` git pushes to `main` |
-
----
-
-## 8 Self-Termination Clause
-
-If an agent detects an unresolvable merge conflict or CI red > 3 runs, it must:
-
-1. Post a comment tagging `@maintainers`.  
-2. Close its own PR with status `blocked`.  
-3. Await human intervention.
-
----
-
-Happy coding 🤖
-```
-
----
-
-**Let me know** when you’re ready for the last two docs—`CONTRIBUTING.md` and `LICENSE.md`—or if you want tweaks to these!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,3 @@
-Below are the last two root-level meta files.
-Copy them straight into your repo and you now have the **full six-file AI-friendly spec suite**. 🚀
-
----
-
-## `CONTRIBUTING.md`
-
-````markdown
 ---
 file: CONTRIBUTING.md
 purpose: Human contribution guide (AIs see AGENT_GUIDE.md)
@@ -14,10 +6,7 @@ updated: 2025-06-14
 
 # Contributing to **GymGenius** 🏋️‍♀️
 
-Thank you for considering a contribution!  
-Whether you’re fixing a typo, building a feature, or hardening the ML engine, we welcome PRs of all sizes.
-
----
+Thank you for considering a contribution! Whether you're fixing a typo, building a feature, or hardening the ML engine, we welcome PRs of all sizes.
 
 ## 1 — Prerequisites
 
@@ -34,27 +23,22 @@ Clone the repo and start the dev stack:
 git clone https://github.com/your-org/gymgenius.git
 cd gymgenius
 make dev      # docker compose up --build
-````
-
----
+```
 
 ## 2 — Issue & Feature Workflow
 
 1. **Search first** – avoid duplicates.
 2. Open an **Issue** using the correct template:
-
    * 🐞 Bug report
    * 💡 Feature request
 3. A maintainer will triage and assign a *task-ID* (see `ROADMAP.md`).
 4. Create a branch: `git checkout -b P2-FE-002/new-tooltip`.
 
----
-
 ## 3 — Branch & Commit Conventions
 
-| Convention | Example                                                                               |
-| ---------- | ------------------------------------------------------------------------------------- |
-| Branch     | `P<phase>-<area>-NNN/<short-desc>`<br>`P1-BE-001/add-login`                           |
+| Convention | Example |
+| ---------- | ------------------------------------------------------------------ |
+| Branch     | `P<phase>-<area>-NNN/<short-desc>`<br>`P1-BE-001/add-login` |
 | Commit     | Conventional Commits + task-ID in scope:<br>`feat(api): P1-BE-003 add refresh tokens` |
 
 **Commit structure**
@@ -69,8 +53,6 @@ Refs: #<issue-number>
 
 *Allowed* types: `feat`, `fix`, `refactor`, `chore`, `docs`, `test`.
 
----
-
 ## 4 — Code Style & Tooling
 
 | Language     | Formatter       | Linter          | Command          |
@@ -81,8 +63,6 @@ Refs: #<issue-number>
 
 * Breaking lint rules blocks CI.
 * Do **not** commit with warnings suppressed via `// eslint-disable`. Fix the root cause.
-
----
 
 ## 5 — Tests & Coverage
 
@@ -99,8 +79,6 @@ make test       # runs both jest & pytest
 
 PRs failing to meet coverage will not pass CI unless tagged `#skip-cov` by a maintainer.
 
----
-
 ## 6 — Database Migrations
 
 1. Modify the Prisma schema.
@@ -109,8 +87,6 @@ PRs failing to meet coverage will not pass CI unless tagged `#skip-cov` by a mai
 4. Update seed scripts if necessary.
 
 Migrations **must** be backward-compatible until a major version bump.
-
----
 
 ## 7 — Pull-Request Checklist
 
@@ -124,8 +100,6 @@ Migrations **must** be backward-compatible until a major version bump.
 
 Two approvals required (one may be from an automation account).
 
----
-
 ## 8 — Release Flow
 
 1. Maintainer merges PRs → `main`.
@@ -133,13 +107,9 @@ Two approvals required (one may be from an automation account).
 3. GitHub Actions tags Docker images and deploys to **staging**; smoke tests run.
 4. Manual promotion → **production** with `gh workflow run deploy-prod`.
 
----
-
 ## 9 — Code of Conduct
 
 All participants must abide by the [Contributor Covenant v2.1](CODE_OF_CONDUCT.md).
-
----
 
 ## 10 — Security & Disclosure
 
@@ -147,49 +117,4 @@ All participants must abide by the [Contributor Covenant v2.1](CODE_OF_CONDUCT.m
 * Please **do not** open GitHub Issues for security matters.
 * We follow a 90-day public disclosure window.
 
----
-
 Happy lifting & coding! 💪
-
-````
-
----
-
-## `LICENSE.md`  (MIT)
-
-```text
-MIT License
-
-Copyright (c) 2025 GymGenius Contributors
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-````
-
----
-
-🎉 **Your lean, AI-ready repo scaffold is now complete**:
-
-* `README.md`
-* `ROADMAP.md`
-* `ARCHITECTURE.md`
-* `AGENT_GUIDE.md`
-* `CONTRIBUTING.md`
-* `LICENSE.md`
-
-Ping me anytime for deeper dives (e.g., test templates, CI config, or detailed API specs).

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 GymGenius Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,6 @@
-Below are **complete, copy-paste-ready drafts** for the first two meta files:
-
----
-
-## `README.md`
-
-````markdown
 ---
 name:        GymGenius
-tagline:     "The AI-Powered Adaptive Training System That Thinks So You Don’t Have To"
+tagline:     "The AI-Powered Adaptive Training System That Thinks So You Don\'t Have To"
 version:     0.1.0
 phase:       alpha
 license:     MIT
@@ -25,8 +18,6 @@ license:     MIT
 | ![license](https://img.shields.io/badge/License-MIT-blue.svg) | MIT license |
 | ![phase](https://img.shields.io/badge/Phase-Alpha-yellow) | Current roadmap phase |
 
----
-
 ## Table of Contents
 1. [Why GymGenius?](#why-gymgenius)
 2. [Quick Start](#quick-start)
@@ -37,15 +28,11 @@ license:     MIT
 7. [Community & Support](#community--support)
 8. [License](#license)
 
----
-
 ### Why GymGenius?
 
-* **Zero Thinking** – automatic load, rep, and rest prescriptions  
-* **Evidence-Based** – mechanical-tension & volume-landmarks baked in  
-* **Truly Adaptive** – learns your recovery τ and RIR bias every session  
-
----
+* **Zero Thinking** – automatic load, rep, and rest prescriptions
+* **Evidence-Based** – mechanical-tension & volume-landmarks baked in
+* **Truly Adaptive** – learns your recovery τ and RIR bias every session
 
 ### Quick Start
 
@@ -59,11 +46,9 @@ make dev            # alias for `docker compose -f docker-compose.dev.yml up --b
 
 # 3 Visit the app
 open http://localhost:3000
-````
+```
 
 > **Prerequisites**: Docker ≥ 24, Node 18 LTS, Make, GNU Bash (macOS/Linux) or WSL 2 (Windows).
-
----
 
 ### Project Structure
 
@@ -77,8 +62,6 @@ open http://localhost:3000
 | `/docs/`               | Architecture diagrams, research white-papers |
 | `docker-compose.*.yml` | Local vs CI vs prod stacks                   |
 
----
-
 ### Tech Stack
 
 * **Frontend**: React + TypeScript + Vite, Zustand state, Tailwind UI
@@ -89,20 +72,15 @@ open http://localhost:3000
 
 > Full dependency matrix lives in **[`TECH_STACK.md`](TECH_STACK.md)**.
 
----
-
 ### Contributing
 
 1. Read **[`AGENT_GUIDE.md`](AGENT_GUIDE.md)** if you are an autonomous coding agent.
 2. Humans: see **[`CONTRIBUTING.md`](CONTRIBUTING.md)** for branch naming, commit style, and PR checklist.
 3. Run `make lint && make test` before every PR.
 
----
-
 ### Roadmap
 
-The current roadmap lives in **[`ROADMAP.md`](ROADMAP.md)**.
-High-level phases:
+The current roadmap lives in **[`ROADMAP.md`](ROADMAP.md)**. High-level phases:
 
 | Phase | Key Outcome                                        |
 | ----- | -------------------------------------------------- |
@@ -111,92 +89,12 @@ High-level phases:
 | v1    | Public launch; plan templates, plateau detection   |
 | v2    | Marketplace & social features                      |
 
----
-
 ### Community & Support
 
 * Discord: `https://discord.gg/gymgenius` – real-time chat
 * Discussions: GitHub → **Discussions** tab
 * Found a bug? Open an Issue with a reproducible snippet.
 
----
-
 ### License
 
 Distributed under the **MIT License** – see **[`LICENSE.md`](LICENSE.md)** for full text.
-
-````
-
----
-
-## `ROADMAP.md`
-
-```markdown
-# GymGenius — Product & Engineering Roadmap
-
-> **Format rules (AI-friendly)**  
-> • Every task has a unique ID: `P<phase>-<area>-NNN`.  
-> • Area codes: `BE` backend, `FE` frontend, `DS` data-science, `INF` infra, `PM` product-mgmt.  
-> • Check-boxes show live status so agents can grep for `" - [ ] "`.
-
----
-
-## Phase 1 — Alpha (internal dog-food)   📅 May → July 2025
-| ID | Owner | Description | Done |
-|----|-------|-------------|------|
-| **P1-BE-001** | `@api-team` | Bootstrap PostgreSQL schema & seed data | - [ ] |
-| **P1-INF-002** | `@infra` | Docker-compose dev stack + Makefile | - [ ] |
-| **P1-FE-003** | `@web` | Minimal PWA: login → workout list → log set | - [ ] |
-| **P1-DS-004** | `@engine` | Extended-Epley 1RM endpoint (`/v1/predict`) | - [ ] |
-| **P1-FE-005** | `@web` | RIR + weight input form with plate rounding | - [ ] |
-| **P1-INF-006** | `@infra` | GitHub Actions CI (lint, test, docker build) | - [ ] |
-| **P1-PM-007** | `@product` | 10-user internal test cohort recruited | - [ ] |
-
-**Exit criteria**  
-* ≥ 80 % of test lifts logged without manual weight edits  
-* Crash-free sessions > 98 %
-
----
-
-## Phase 2 — Private Beta (≤ 100 users)   📅 Aug → Oct 2025
-| ID | Owner | Description | Done |
-|----|-------|-------------|------|
-| **P2-DS-001** | `@engine` | RIR-bias learning + fatigue decay model | - [ ] |
-| **P2-FE-002** | `@web` | “Why this weight?” tooltip (explainable AI) | - [ ] |
-| **P2-BE-003** | `@api-team` | Webhook → nightly model-training pipeline | - [ ] |
-| **P2-INF-004** | `@infra` | Staging environment (AWS ECS + RDS) | - [ ] |
-| **P2-PM-005** | `@product` | Beta feedback survey + KPI dashboard | - [ ] |
-
-Exit criteria: **day-7 retention ≥ 50 %**, MAE < 2.5 % on weight predictions.
-
----
-
-## Phase 3 — Public v1   📅 Nov 2025 → Jan 2026
-| ID | Owner | Description | Done |
-|----|-------|-------------|------|
-| **P3-FE-001** | `@web` | Plan template library & floating rest days | - [ ] |
-| **P3-DS-002** | `@engine` | Plateau detection + auto-deload protocol | - [ ] |
-| **P3-FE-003** | `@web` | Analytics dashboard (1RM graph, volume heatmap) | - [ ] |
-| **P3-INF-004** | `@infra` | Observability stack (Datadog, OpenTelemetry) | - [ ] |
-| **P3-PM-005** | `@product` | Freemium pricing & subscription flow | - [ ] |
-
-Exit criteria: **1 k monthly active lifters**, churn < 5 % / month.
-
----
-
-## Phase 4 — v2+ (Community & Marketplace)   📅 TBD 2026
-High-level epics (details will be added closer to start date):
-
-* **Program Marketplace** – coach uploads, revenue share  
-* **Social Layer** – challenges, form-check videos  
-* **Camera-based Velocity Estimation** – optional phone capture  
-* **Wearable Readiness Import** – HRV & sleep auto-adjust loads  
-
----
-
-### Change-Management
-
-* Edit this file via **pull request** only.  
-* Keep task IDs immutable; superseded items get a trailing `-X` suffix.  
-* CI fails if a phase contains unchecked tasks but has an `exit_criteria_met` flag.
-

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,57 @@
+# GymGenius — Product & Engineering Roadmap
+
+> **Format rules (AI-friendly)**
+> - Every task has a unique ID: `P<phase>-<area>-NNN`.
+> - Area codes: `BE` backend, `FE` frontend, `DS` data-science, `INF` infra, `PM` product-mgmt.
+> - Check-boxes show live status so agents can grep for " - [ ] ".
+
+## Phase 1 — Alpha (internal dog-food)   📅 May → July 2025
+| ID | Owner | Description | Done |
+|----|-------|-------------|------|
+| **P1-BE-001** | `@api-team` | Bootstrap PostgreSQL schema & seed data | - [ ] |
+| **P1-INF-002** | `@infra` | Docker-compose dev stack + Makefile | - [ ] |
+| **P1-FE-003** | `@web` | Minimal PWA: login → workout list → log set | - [ ] |
+| **P1-DS-004** | `@engine` | Extended-Epley 1RM endpoint (`/v1/predict`) | - [ ] |
+| **P1-FE-005** | `@web` | RIR + weight input form with plate rounding | - [ ] |
+| **P1-INF-006** | `@infra` | GitHub Actions CI (lint, test, docker build) | - [ ] |
+| **P1-PM-007** | `@product` | 10-user internal test cohort recruited | - [ ] |
+
+**Exit criteria**
+* ≥ 80 % of test lifts logged without manual weight edits
+* Crash-free sessions > 98 %
+
+## Phase 2 — Private Beta (≤ 100 users)   📅 Aug → Oct 2025
+| ID | Owner | Description | Done |
+|----|-------|-------------|------|
+| **P2-DS-001** | `@engine` | RIR-bias learning + fatigue decay model | - [ ] |
+| **P2-FE-002** | `@web` | “Why this weight?” tooltip (explainable AI) | - [ ] |
+| **P2-BE-003** | `@api-team` | Webhook → nightly model-training pipeline | - [ ] |
+| **P2-INF-004** | `@infra` | Staging environment (AWS ECS + RDS) | - [ ] |
+| **P2-PM-005** | `@product` | Beta feedback survey + KPI dashboard | - [ ] |
+
+Exit criteria: **day-7 retention ≥ 50 %**, MAE < 2.5 % on weight predictions.
+
+## Phase 3 — Public v1   📅 Nov 2025 → Jan 2026
+| ID | Owner | Description | Done |
+|----|-------|-------------|------|
+| **P3-FE-001** | `@web` | Plan template library & floating rest days | - [ ] |
+| **P3-DS-002** | `@engine` | Plateau detection + auto-deload protocol | - [ ] |
+| **P3-FE-003** | `@web` | Analytics dashboard (1RM graph, volume heatmap) | - [ ] |
+| **P3-INF-004** | `@infra` | Observability stack (Datadog, OpenTelemetry) | - [ ] |
+| **P3-PM-005** | `@product` | Freemium pricing & subscription flow | - [ ] |
+
+Exit criteria: **1 k monthly active lifters**, churn < 5 % / month.
+
+## Phase 4 — v2+ (Community & Marketplace)   📅 TBD 2026
+High-level epics (details will be added closer to start date):
+
+* **Program Marketplace** – coach uploads, revenue share
+* **Social Layer** – challenges, form-check videos
+* **Camera-based Velocity Estimation** – optional phone capture
+* **Wearable Readiness Import** – HRV & sleep auto-adjust loads
+
+### Change-Management
+
+* Edit this file via **pull request** only.
+* Keep task IDs immutable; superseded items get a trailing `-X` suffix.
+* CI fails if a phase contains unchecked tasks but has an `exit_criteria_met` flag.


### PR DESCRIPTION
## Summary
- rewrite README with clean formatting
- split roadmap into `ROADMAP.md`
- split agent guidelines into `AGENT_GUIDE.md`
- clean up architecture and contributing docs
- add `LICENSE.md`

## Testing
- `make lint` *(fails: No rule to make target)*
- `make test` *(fails: No rule to make target)*

------
https://chatgpt.com/codex/tasks/task_e_684d71f9942883299048e86a24e7cd52