### PR TITLE
[P4-INF-011] Clarify local-first roadmap

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -9,7 +9,7 @@ flowchart LR
     subgraph Client
         A[Web PWA<br/>React + TS]
     end
-    subgraph AWS ECS Cluster
+    subgraph Docker Compose Network
         B(API Service<br/>Node 18)
         C(ML Engine<br/>Python 3.11)
         D(Job Worker<br/>Bull Queue)
@@ -65,7 +65,7 @@ flowchart LR
   "datastores": [
     { "name": "postgres", "type": "sql", "image": "postgres:16" },
     { "name": "redis", "type": "cache", "image": "redis:7" },
-    { "name": "s3", "type": "object_storage", "provider": "aws" }
+    { "name": "s3", "type": "object_storage", "provider": "minio" }
   ]
 }
 ```
@@ -88,7 +88,7 @@ Agents can parse this JSON to auto-map folder names to Docker services.
 * **Monorepo** (`pnpm workspace`) until MAU > 50 k → TDR-001
 * **Postgres** over Mongo for relational complexity → TDR-002
 * **Redis** chosen for both cache and queue broker → TDR-003
-* **Docker Compose** in dev; ECS Fargate in prod → TDR-004
+* **Docker Compose** in dev; AWS ECS Fargate in production (Phase 4+) → TDR-004
 
 (TDR docs live in `docs/tdr/`.)
 
@@ -97,12 +97,12 @@ Agents can parse this JSON to auto-map folder names to Docker services.
 | Environment | URL                             | Authentication   | Deploy Trigger      |
 | ----------- | ------------------------------- | ---------------- | ------------------- |
 | Local       | `localhost:*`                   | none             | `make dev`          |
-| Staging     | `https://staging.gymgenius.app` | Auth0 dev tenant | Merge → `main`      |
-| Production  | `https://app.gymgenius.app`     | Auth0 prod       | GitHub Release `v*` |
+| Local-Staging | `localhost` ports | none | `docker compose -f docker-compose.staging.yml up` |
+| Production (Phase 4+) | `https://app.gymgenius.app` | Auth0 prod | GitHub Release `v*` |
 
 ## 6 Scaling Plan
 
-1. **Vertical**: bump ECS task CPU/RAM (target P99 < 150 ms).
+1. **Vertical**: bump container CPU/RAM (target P99 < 150 ms).
 2. **Read Replicas**: Postgres --> Aurora Serverless v2.
 3. **Service Split**: if `engine` CPU > 70 %, move to GPU node pool.
 

--- a/ProjectVISION.md
+++ b/ProjectVISION.md
@@ -549,7 +549,7 @@ class UserLearningModel:
 - **API**: RESTful with OpenAPI documentation
 
 ### Infrastructure
-- **Hosting**: AWS or Google Cloud Platform
+- **Hosting**: Local Docker Compose initially; later deployable to AWS or another cloud provider
 - **Container**: Docker with Kubernetes
 - **CI/CD**: GitHub Actions
 - **Monitoring**: Sentry for errors, Datadog for metrics

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ open http://localhost:3000
 * **Frontend**: React + TypeScript + Vite, Zustand state, Tailwind UI
 * **Backend**: Node 18, Express / Fastify, PostgreSQL 16, Redis 7
 * **ML Service**: Python 3.11, PyTorch 2.3, FastAPI, pydantic
-* **DevOps**: Docker, GitHub Actions, Terraform + AWS ECS (prod)
+* **DevOps**: Docker, GitHub Actions; cloud deployment via AWS ECS planned for Phase 4
 * **Observability**: Sentry, Datadog, OpenTelemetry traces
 
 > Full dependency matrix lives in **[`TECH_STACK.md`](TECH_STACK.md)**.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -30,7 +30,7 @@
 | **P2-DS-001** | `@engine` | Implement core adaptive algorithm components: RIR-bias learning, fatigue tracking model (user-specific), initial weight recommendation logic. | - [ ] |
 | **P2-FE-002** | `@web` | “Why this weight?” tooltip (explainable AI) | - [ ] |
 | **P2-BE-003** | `@api-team` | Webhook → nightly model-training pipeline | - [ ] |
-| **P2-INF-004** | `@infra` | Staging environment (AWS ECS + RDS) | - [ ] |
+| **P2-INF-004** | `@infra` | Local staging environment via Docker Compose; AWS deployment deferred to Phase 4 (see P4-INF-011) | - [ ] |
 | **P2-PM-005** | `@product` | Beta feedback survey + KPI dashboard | - [ ] |
 | **P2-DS-006** | `@engine` | Implement trend detection for exercise performance. | - [ ] |
 | **P2-DS-007** | `@engine` | Implement basic plateau detection (based on trend). | - [ ] |
@@ -71,6 +71,8 @@ Exit criteria: **1 k monthly active lifters**, churn < 5 % / month.
 | **P4-PM-008** | `@product` | Implement detailed analytics tracking (e.g., Mixpanel) for user behavior. | - [ ] |
 | **P4-DOC-009** | `@product` | Create user and technical documentation. | - [ ] |
 | **P4-PM-010** | `@product` | Coordinate beta testing with a larger cohort of real users. | - [ ] |
+| **P4-INF-011** | `@infra` | Deploy to AWS ECS + RDS for production rollout | - [ ] |
+| **P4-INF-012** | `@infra` | CI/CD pipeline to push images to ECR and update ECS services | - [ ] |
 
 ## Phase 5 — Advanced Features (Post-Launch) 📅 [Date TBD]
 | ID | Owner | Description | Done |

--- a/TODO.md
+++ b/TODO.md
@@ -16,7 +16,7 @@ This file lists the next logical tasks to be done in the GymGenius project.
 - [x] **P2-DS-001**: `@engine` RIR-bias learning + fatigue decay model
 - [x] **P2-FE-002**: `@web` “Why this weight?” tooltip (explainable AI)
 - [x] **P2-BE-003**: `@api-team` Webhook → nightly model-training pipeline
-- [x] **P2-INF-004**: `@infra` Staging environment (AWS ECS + RDS) - (_Documentation for setup and conceptual `docker-compose.staging.yml` created in `infrastructure/aws/`_)
+- [x] **P2-INF-004**: `@infra` Local staging environment via Docker Compose; AWS deployment moved to Phase 4
 - [x] **P2-PM-005**: `@product` Beta feedback survey + KPI dashboard - (_Draft survey questions and KPI dashboard outline created in `PRODUCT_FEEDBACK.md`_)
 
 ## Phase 3 - Public v1

--- a/infrastructure/aws/README.md
+++ b/infrastructure/aws/README.md
@@ -1,5 +1,7 @@
 # Staging Environment Setup on AWS ECS + RDS
 
+> **Note**: The project runs entirely on local Docker Compose during Phases 1-3. This guide applies only when transitioning to cloud hosting in Phase 4 and beyond.
+
 This document outlines the conceptual steps and considerations for deploying the GymGenius application to a staging environment using AWS Elastic Container Service (ECS) and AWS Relational Database Service (RDS) for PostgreSQL.
 
 ## Overview


### PR DESCRIPTION
## Summary
- emphasize Docker compose approach in early phases
- postpone AWS tasks until Phase 4 in roadmap and todo list
- note local-first hosting in ProjectVISION and architecture docs
- clarify AWS docs apply only for later phases

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_684d9eac4c788329a87331a301e024d6