### PR TITLE
[P2-INF-004] bump postgres version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - db
       - engine
   db:
-    image: postgres:13-alpine
+    image: postgres:16-alpine
     volumes:
       - postgres_data:/var/lib/postgresql/data/
     environment:


### PR DESCRIPTION
## Summary
- update postgres service to use version 16

## Testing
- `make lint`
- `make test`
- `python3 database/create_schema.py` *(fails: ModuleNotFoundError: psycopg2)*
- `python3 database/seed_data.py` *(fails: ModuleNotFoundError: psycopg2)*

------
https://chatgpt.com/codex/tasks/task_e_684dabc94730832981a17403ca2eb4ac