### PR TITLE
[P1-PM-007] Sync cohort status across docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **P2-INF-004**: Documented conceptual setup for a staging environment on AWS ECS + RDS in `infrastructure/aws/README.md` and provided an illustrative `docker-compose.staging.yml`.
 - **P2-PM-005**: Drafted beta feedback survey questions and a KPI dashboard outline in `PRODUCT_FEEDBACK.md`.
 
+### Changed
+- **P1-PM-007**: Updated `ROADMAP.md` checkbox to mark the 10-user cohort as complete, matching `TODO.md`.
+
 ## [0.2.0] - 2024-08-02 - Phase 2 Beta Features
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,7 +14,7 @@
 | **P1-DS-004** | `@engine` | Implement `estimate_1rm` (Extended Epley) & `calculate_training_params` as foundation for progression. | - [x] |
 | **P1-FE-005** | `@web` | RIR + weight input form with plate rounding | - [x] |
 | **P1-INF-006** | `@infra` | GitHub Actions CI (lint, test, docker build) | - [x] |
-| **P1-PM-007** | `@product` | 10-user internal test cohort recruited | - [ ] |
+| **P1-PM-007** | `@product` | 10-user internal test cohort recruited | - [x] |
 | **P1-BE-008** | `@api-team` | Implement Authentication backend (signup/login/JWT management). | - [x] |
 | **P1-BE-009** | `@api-team` | Implement User Profile Management APIs (CRUD for user settings, goals, equipment). | - [x] |
 | **P1-BE-010** | `@api-team` | Implement Basic CRUD APIs for Exercises (create, read, update, delete - admin initially). | - [x] |


### PR DESCRIPTION
## Summary
- mark the 10-user test cohort as complete in ROADMAP
- add changelog note for the status update

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_684dabc4c7bc8329bb1f8e53fe069bab