### PR TITLE
[P0-TRIVIAL] enforce ruff errors in lint-engine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ lint-web:
 
 lint-engine:
 	@echo 'Linting engine...'
-	ruff check engine tests webapp/tests || true
+	ruff check engine tests webapp/tests
 	@echo 'Engine linting complete.'
 
 lint: lint-web lint-engine


### PR DESCRIPTION
## Summary
- remove `|| true` from `lint-engine` to stop suppressing ruff errors

## Testing
- `make lint` *(fails: ruff reports lint errors)*
- `make test` *(fails: ModuleNotFoundError: No module named 'flask')*
- `make build` *(fails: docker-compose not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e9d16d16c83298cd9e3ee9275373b