### PR TITLE
feat: Implement Phase 3 Backend Functionality

### DIFF
--- a/engine/app.py
+++ b/engine/app.py
@@ -990,6 +990,883 @@ def recommend_set_parameters_route(user_id, exercise_id):
         if conn:
             conn.close()
 
+# --- Workout Plan Builder Endpoints ---
+
+@app.route('/v1/users/<uuid:user_id>/plans', methods=['POST'])
+@jwt_required
+def create_workout_plan(user_id):
+    from flask import g
+    if str(user_id) != g.current_user_id:
+        logger.warning(f"Forbidden attempt to create plan for user {user_id} by user {g.current_user_id}")
+        return jsonify(error="Forbidden. You can only create plans for your own profile."), 403
+
+    data = request.get_json()
+    if not data:
+        return jsonify(error="Request body must be JSON"), 400
+
+    plan_name = data.get('name')
+    if not plan_name:
+        return jsonify(error="Missing required field: name"), 400
+
+    # Optional fields
+    days_per_week = data.get('days_per_week')
+    plan_length_weeks = data.get('plan_length_weeks')
+    goal_focus = data.get('goal_focus') # E.g., "strength", "hypertrophy", "endurance"
+
+    # Validate optional fields if present
+    if days_per_week is not None:
+        try:
+            days_per_week = int(days_per_week)
+            if not (1 <= days_per_week <= 7):
+                raise ValueError("Days per week must be between 1 and 7.")
+        except ValueError as e:
+            return jsonify(error=f"Invalid 'days_per_week': {e}"), 400
+
+    if plan_length_weeks is not None:
+        try:
+            plan_length_weeks = int(plan_length_weeks)
+            if plan_length_weeks < 1:
+                raise ValueError("Plan length must be at least 1 week.")
+        except ValueError as e:
+            return jsonify(error=f"Invalid 'plan_length_weeks': {e}"), 400
+
+    plan_id = str(uuid.uuid4())
+    conn = None
+    try:
+        conn = get_db_connection()
+        with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute(
+                """
+                INSERT INTO workout_plans (id, user_id, name, days_per_week, plan_length_weeks, goal_focus, created_at, updated_at)
+                VALUES (%s, %s, %s, %s, %s, %s, NOW(), NOW())
+                RETURNING *;
+                """,
+                (plan_id, str(user_id), plan_name, days_per_week, plan_length_weeks, goal_focus)
+            )
+            new_plan = cur.fetchone()
+            conn.commit()
+            logger.info(f"Workout plan '{plan_name}' (ID: {plan_id}) created successfully for user: {user_id}")
+            return jsonify(new_plan), 201
+
+    except psycopg2.Error as e:
+        logger.error(f"Database error creating workout plan for user {user_id}: {e}")
+        if conn:
+            conn.rollback()
+        return jsonify(error="Database operation failed creating workout plan"), 500
+    except Exception as e:
+        logger.error(f"Unexpected error creating workout plan for user {user_id}: {e}", exc_info=True)
+        if conn:
+            conn.rollback()
+        return jsonify(error="An unexpected error occurred creating workout plan"), 500
+    finally:
+        if conn:
+            conn.close()
+
+@app.route('/v1/users/<uuid:user_id>/plans', methods=['GET'])
+@jwt_required
+def get_workout_plans_for_user(user_id):
+    from flask import g
+    if str(user_id) != g.current_user_id:
+        logger.warning(f"Forbidden attempt to get plans for user {user_id} by user {g.current_user_id}")
+        return jsonify(error="Forbidden. You can only view your own plans."), 403
+
+    conn = None
+    try:
+        conn = get_db_connection()
+        with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute(
+                "SELECT * FROM workout_plans WHERE user_id = %s ORDER BY created_at DESC;",
+                (str(user_id),)
+            )
+            plans_list = cur.fetchall()
+
+            return jsonify(plans_list), 200
+
+    except psycopg2.Error as e:
+        logger.error(f"Database error fetching workout plans for user {user_id}: {e}")
+        return jsonify(error="Database operation failed fetching workout plans"), 500
+    except Exception as e:
+        logger.error(f"Unexpected error fetching workout plans for user {user_id}: {e}", exc_info=True)
+        return jsonify(error="An unexpected error occurred fetching workout plans"), 500
+    finally:
+        if conn:
+            conn.close()
+
+@app.route('/v1/plans/<uuid:plan_id>', methods=['GET'])
+@jwt_required
+def get_workout_plan_details(plan_id):
+    from flask import g
+    conn = None
+    try:
+        conn = get_db_connection()
+        with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            # Fetch the plan
+            cur.execute("SELECT * FROM workout_plans WHERE id = %s;", (str(plan_id),))
+            plan = cur.fetchone()
+
+            if not plan:
+                return jsonify(error="Workout plan not found"), 404
+
+            # Verify ownership
+            if plan['user_id'] != uuid.UUID(g.current_user_id):
+                logger.warning(f"Forbidden attempt to access plan {plan_id} by user {g.current_user_id}")
+                return jsonify(error="Forbidden. You do not own this plan."), 403
+
+            # Fetch associated plan days
+            cur.execute(
+                "SELECT * FROM plan_days WHERE plan_id = %s ORDER BY day_number ASC;",
+                (str(plan_id),)
+            )
+            plan_days = cur.fetchall()
+
+            # For each plan day, fetch its exercises
+            for day in plan_days:
+                cur.execute(
+                    """
+                    SELECT pe.*, e.name as exercise_name
+                    FROM plan_exercises pe
+                    JOIN exercises e ON pe.exercise_id = e.id
+                    WHERE pe.plan_day_id = %s
+                    ORDER BY pe.order_index ASC;
+                    """,
+                    (str(day['id']),)
+                )
+                day['exercises'] = cur.fetchall()
+
+            plan['days'] = plan_days
+            return jsonify(plan), 200
+
+    except psycopg2.Error as e:
+        logger.error(f"Database error fetching details for plan {plan_id}: {e}")
+        return jsonify(error="Database operation failed fetching plan details"), 500
+    except Exception as e:
+        logger.error(f"Unexpected error fetching details for plan {plan_id}: {e}", exc_info=True)
+        return jsonify(error="An unexpected error occurred fetching plan details"), 500
+    finally:
+        if conn:
+            conn.close()
+
+@app.route('/v1/plans/<uuid:plan_id>', methods=['PUT'])
+@jwt_required
+def update_workout_plan(plan_id):
+    from flask import g
+    data = request.get_json()
+    if not data:
+        return jsonify(error="Request body must be JSON"), 400
+
+    conn = None
+    try:
+        conn = get_db_connection()
+        with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            # Fetch the plan to verify ownership
+            cur.execute("SELECT user_id FROM workout_plans WHERE id = %s;", (str(plan_id),))
+            plan_owner = cur.fetchone()
+
+            if not plan_owner:
+                return jsonify(error="Workout plan not found"), 404
+
+            if plan_owner['user_id'] != uuid.UUID(g.current_user_id):
+                logger.warning(f"Forbidden attempt to update plan {plan_id} by user {g.current_user_id}")
+                return jsonify(error="Forbidden. You do not own this plan."), 403
+
+            # Fields that can be updated
+            allowed_fields = {
+                'name': str,
+                'days_per_week': int,
+                'plan_length_weeks': int,
+                'goal_focus': str,
+                'is_active': bool # Example: allowing to activate/deactivate a plan
+            }
+
+            update_fields_parts = []
+            update_values = []
+
+            for field, field_type in allowed_fields.items():
+                if field in data:
+                    value = data[field]
+                    # Basic type validation
+                    if value is not None: # Allow fields to be set to null if appropriate for DB schema
+                        if field_type is int and isinstance(value, float) and value.is_integer():
+                            value = int(value) # Allow float if it's a whole number for int fields
+                        elif not isinstance(value, field_type):
+                            return jsonify(error=f"Invalid type for field '{field}'. Expected {field_type.__name__}."), 400
+
+                    # Specific validation for certain fields
+                    if field == 'days_per_week' and value is not None and not (1 <= value <= 7):
+                        return jsonify(error="'days_per_week' must be between 1 and 7"), 400
+                    if field == 'plan_length_weeks' and value is not None and value < 0: # 0 could mean ongoing
+                        return jsonify(error="'plan_length_weeks' must be non-negative"), 400
+
+                    update_fields_parts.append(f"{field} = %s")
+                    update_values.append(value)
+
+            if not update_fields_parts:
+                return jsonify(error="No valid fields provided for update"), 400
+
+            update_fields_parts.append("updated_at = NOW()")
+            query = f"UPDATE workout_plans SET {', '.join(update_fields_parts)} WHERE id = %s RETURNING *;"
+            update_values.append(str(plan_id))
+
+            cur.execute(query, tuple(update_values))
+            updated_plan = cur.fetchone()
+            conn.commit()
+
+            logger.info(f"Workout plan {plan_id} updated successfully by user {g.current_user_id}")
+            return jsonify(updated_plan), 200
+
+    except psycopg2.Error as e:
+        logger.error(f"Database error updating plan {plan_id}: {e}")
+        if conn:
+            conn.rollback()
+        return jsonify(error="Database operation failed updating plan"), 500
+    except Exception as e:
+        logger.error(f"Unexpected error updating plan {plan_id}: {e}", exc_info=True)
+        if conn:
+            conn.rollback()
+        return jsonify(error="An unexpected error occurred updating plan"), 500
+    finally:
+        if conn:
+            conn.close()
+
+@app.route('/v1/plans/<uuid:plan_id>', methods=['DELETE'])
+@jwt_required
+def delete_workout_plan(plan_id):
+    from flask import g
+    conn = None
+    try:
+        conn = get_db_connection()
+        with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            # Fetch the plan to verify ownership before deleting
+            cur.execute("SELECT user_id FROM workout_plans WHERE id = %s;", (str(plan_id),))
+            plan_owner = cur.fetchone()
+
+            if not plan_owner:
+                return jsonify(error="Workout plan not found"), 404
+
+            if plan_owner['user_id'] != uuid.UUID(g.current_user_id):
+                logger.warning(f"Forbidden attempt to delete plan {plan_id} by user {g.current_user_id}")
+                return jsonify(error="Forbidden. You do not own this plan."), 403
+
+            # Delete the plan. Associated plan_days and plan_exercises should be deleted by CASCADE.
+            cur.execute("DELETE FROM workout_plans WHERE id = %s;", (str(plan_id),))
+            conn.commit()
+
+            # Check if deletion was successful
+            if cur.rowcount == 0:
+                # This case should ideally be caught by the initial check, but as a safeguard:
+                logger.error(f"Failed to delete plan {plan_id}, though ownership was verified. Plan might have been deleted by another process.")
+                return jsonify(error="Failed to delete plan, it might have already been deleted."), 404
+
+            logger.info(f"Workout plan {plan_id} deleted successfully by user {g.current_user_id}")
+            return '', 204 # No content
+
+    except psycopg2.Error as e:
+        logger.error(f"Database error deleting plan {plan_id}: {e}")
+        if conn:
+            conn.rollback()
+        # Consider if this should be 500 or if specific psycopg2 errors might indicate a 404 (e.g., foreign key constraint)
+        return jsonify(error="Database operation failed deleting plan"), 500
+    except Exception as e:
+        logger.error(f"Unexpected error deleting plan {plan_id}: {e}", exc_info=True)
+        if conn:
+            conn.rollback()
+        return jsonify(error="An unexpected error occurred deleting plan"), 500
+    finally:
+        if conn:
+            conn.close()
+
+# --- Plan Day Endpoints ---
+
+@app.route('/v1/plans/<uuid:plan_id>/days', methods=['POST'])
+@jwt_required
+def create_plan_day(plan_id):
+    from flask import g
+    data = request.get_json()
+    if not data:
+        return jsonify(error="Request body must be JSON"), 400
+
+    day_number = data.get('day_number')
+    if day_number is None: # Check for None specifically, as 0 could be a valid day_number in some systems
+        return jsonify(error="Missing required field: day_number"), 400
+
+    try:
+        day_number = int(day_number)
+        if day_number < 0: # Or 1 if day numbers are 1-indexed
+             raise ValueError("day_number must be a non-negative integer.")
+    except ValueError as e:
+        return jsonify(error=f"Invalid 'day_number': {e}"), 400
+
+    day_name = data.get('name') # Optional
+
+    conn = None
+    try:
+        conn = get_db_connection()
+        with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            # Verify ownership of the parent plan
+            cur.execute("SELECT user_id FROM workout_plans WHERE id = %s;", (str(plan_id),))
+            plan_owner = cur.fetchone()
+
+            if not plan_owner:
+                return jsonify(error="Parent workout plan not found"), 404
+
+            if plan_owner['user_id'] != uuid.UUID(g.current_user_id):
+                logger.warning(f"Forbidden attempt to add day to plan {plan_id} by user {g.current_user_id}")
+                return jsonify(error="Forbidden. You do not own this plan."), 403
+
+            # Check if a day with the same day_number already exists for this plan
+            cur.execute("SELECT id FROM plan_days WHERE plan_id = %s AND day_number = %s;", (str(plan_id), day_number))
+            if cur.fetchone():
+                return jsonify(error=f"A day with day_number {day_number} already exists for this plan."), 409 # Conflict
+
+            plan_day_id = str(uuid.uuid4())
+            cur.execute(
+                """
+                INSERT INTO plan_days (id, plan_id, day_number, name, created_at, updated_at)
+                VALUES (%s, %s, %s, %s, NOW(), NOW())
+                RETURNING *;
+                """,
+                (plan_day_id, str(plan_id), day_number, day_name)
+            )
+            new_plan_day = cur.fetchone()
+            conn.commit()
+            logger.info(f"Plan day {plan_day_id} (Day {day_number}) created for plan {plan_id} by user {g.current_user_id}")
+            return jsonify(new_plan_day), 201
+
+    except psycopg2.Error as e:
+        logger.error(f"Database error creating plan day for plan {plan_id}: {e}")
+        if conn:
+            conn.rollback()
+        return jsonify(error="Database operation failed creating plan day"), 500
+    except Exception as e:
+        logger.error(f"Unexpected error creating plan day for plan {plan_id}: {e}", exc_info=True)
+        if conn:
+            conn.rollback()
+        return jsonify(error="An unexpected error occurred creating plan day"), 500
+    finally:
+        if conn:
+            conn.close()
+
+@app.route('/v1/plans/<uuid:plan_id>/days', methods=['GET'])
+@jwt_required
+def get_plan_days(plan_id):
+    from flask import g
+    conn = None
+    try:
+        conn = get_db_connection()
+        with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            # Verify ownership of the parent plan
+            cur.execute("SELECT user_id FROM workout_plans WHERE id = %s;", (str(plan_id),))
+            plan_owner = cur.fetchone()
+
+            if not plan_owner:
+                return jsonify(error="Parent workout plan not found"), 404
+
+            if plan_owner['user_id'] != uuid.UUID(g.current_user_id):
+                logger.warning(f"Forbidden attempt to get days for plan {plan_id} by user {g.current_user_id}")
+                return jsonify(error="Forbidden. You do not own this plan."), 403
+
+            # Fetch all plan days for this plan
+            cur.execute(
+                "SELECT * FROM plan_days WHERE plan_id = %s ORDER BY day_number ASC;",
+                (str(plan_id),)
+            )
+            plan_days_list = cur.fetchall()
+
+            return jsonify(plan_days_list), 200
+
+    except psycopg2.Error as e:
+        logger.error(f"Database error fetching plan days for plan {plan_id}: {e}")
+        return jsonify(error="Database operation failed fetching plan days"), 500
+    except Exception as e:
+        logger.error(f"Unexpected error fetching plan days for plan {plan_id}: {e}", exc_info=True)
+        return jsonify(error="An unexpected error occurred fetching plan days"), 500
+    finally:
+        if conn:
+            conn.close()
+
+@app.route('/v1/plandays/<uuid:day_id>', methods=['PUT'])
+@jwt_required
+def update_plan_day(day_id):
+    from flask import g
+    data = request.get_json()
+    if not data:
+        return jsonify(error="Request body must be JSON"), 400
+
+    conn = None
+    try:
+        conn = get_db_connection()
+        with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            # Fetch plan day and its parent plan's user_id for ownership verification
+            cur.execute(
+                """
+                SELECT pd.id AS plan_day_id, pd.plan_id, wp.user_id AS plan_owner_id
+                FROM plan_days pd
+                JOIN workout_plans wp ON pd.plan_id = wp.id
+                WHERE pd.id = %s;
+                """, (str(day_id),)
+            )
+            day_info = cur.fetchone()
+
+            if not day_info:
+                return jsonify(error="Plan day not found"), 404
+
+            if day_info['plan_owner_id'] != uuid.UUID(g.current_user_id):
+                logger.warning(f"Forbidden attempt to update plan day {day_id} by user {g.current_user_id}")
+                return jsonify(error="Forbidden. You do not own the parent plan of this day."), 403
+
+            allowed_fields = {'name': str, 'day_number': int}
+            update_fields_parts = []
+            update_values = []
+
+            if 'day_number' in data:
+                try:
+                    day_number = int(data['day_number'])
+                    if day_number < 0: # Or 1 if 1-indexed
+                        raise ValueError("day_number must be a non-negative integer.")
+
+                    # Check for day_number conflict within the same plan
+                    cur.execute(
+                        "SELECT id FROM plan_days WHERE plan_id = %s AND day_number = %s AND id != %s;",
+                        (day_info['plan_id'], day_number, str(day_id))
+                    )
+                    if cur.fetchone():
+                        return jsonify(error=f"A day with day_number {day_number} already exists for this plan."), 409
+
+                    update_fields_parts.append("day_number = %s")
+                    update_values.append(day_number)
+                except ValueError as e:
+                    return jsonify(error=f"Invalid 'day_number': {e}"), 400
+
+            if 'name' in data:
+                name = data['name']
+                if name is not None and not isinstance(name, str): # Allow name to be nullified
+                    return jsonify(error="Invalid type for field 'name'. Expected string or null."), 400
+                update_fields_parts.append("name = %s")
+                update_values.append(name)
+
+            if not update_fields_parts:
+                return jsonify(error="No valid fields provided for update"), 400
+
+            update_fields_parts.append("updated_at = NOW()")
+            query = f"UPDATE plan_days SET {', '.join(update_fields_parts)} WHERE id = %s RETURNING *;"
+            update_values.append(str(day_id))
+
+            cur.execute(query, tuple(update_values))
+            updated_plan_day = cur.fetchone()
+            conn.commit()
+
+            logger.info(f"Plan day {day_id} updated successfully by user {g.current_user_id}")
+            return jsonify(updated_plan_day), 200
+
+    except psycopg2.Error as e:
+        logger.error(f"Database error updating plan day {day_id}: {e}")
+        if conn:
+            conn.rollback()
+        return jsonify(error="Database operation failed updating plan day"), 500
+    except Exception as e:
+        logger.error(f"Unexpected error updating plan day {day_id}: {e}", exc_info=True)
+        if conn:
+            conn.rollback()
+        return jsonify(error="An unexpected error occurred updating plan day"), 500
+    finally:
+        if conn:
+            conn.close()
+
+@app.route('/v1/plandays/<uuid:day_id>', methods=['DELETE'])
+@jwt_required
+def delete_plan_day(day_id):
+    from flask import g
+    conn = None
+    try:
+        conn = get_db_connection()
+        with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            # Fetch plan day and its parent plan's user_id for ownership verification
+            cur.execute(
+                """
+                SELECT wp.user_id AS plan_owner_id
+                FROM plan_days pd
+                JOIN workout_plans wp ON pd.plan_id = wp.id
+                WHERE pd.id = %s;
+                """, (str(day_id),)
+            )
+            day_info = cur.fetchone()
+
+            if not day_info:
+                return jsonify(error="Plan day not found"), 404
+
+            if day_info['plan_owner_id'] != uuid.UUID(g.current_user_id):
+                logger.warning(f"Forbidden attempt to delete plan day {day_id} by user {g.current_user_id}")
+                return jsonify(error="Forbidden. You do not own the parent plan of this day."), 403
+
+            # Delete the plan day. Associated plan_exercises should be deleted by CASCADE.
+            cur.execute("DELETE FROM plan_days WHERE id = %s;", (str(day_id),))
+            conn.commit()
+
+            if cur.rowcount == 0:
+                # Should be caught by the initial check, but as a safeguard
+                logger.error(f"Failed to delete plan day {day_id}, though ownership was verified. Day might have been deleted by another process.")
+                return jsonify(error="Failed to delete plan day, it might have already been deleted."), 404
+
+            logger.info(f"Plan day {day_id} deleted successfully by user {g.current_user_id}")
+            return '', 204
+
+    except psycopg2.Error as e:
+        logger.error(f"Database error deleting plan day {day_id}: {e}")
+        if conn:
+            conn.rollback()
+        return jsonify(error="Database operation failed deleting plan day"), 500
+    except Exception as e:
+        logger.error(f"Unexpected error deleting plan day {day_id}: {e}", exc_info=True)
+        if conn:
+            conn.rollback()
+        return jsonify(error="An unexpected error occurred deleting plan day"), 500
+    finally:
+        if conn:
+            conn.close()
+
+# --- Plan Exercise Endpoints ---
+
+@app.route('/v1/plandays/<uuid:day_id>/exercises', methods=['POST'])
+@jwt_required
+def create_plan_exercise(day_id):
+    from flask import g
+    data = request.get_json()
+    if not data:
+        return jsonify(error="Request body must be JSON"), 400
+
+    required_fields = ['exercise_id', 'order_index', 'sets']
+    for field in required_fields:
+        if field not in data:
+            return jsonify(error=f"Missing required field: {field}"), 400
+
+    try:
+        exercise_id = str(uuid.UUID(data['exercise_id'])) # Validate UUID
+        order_index = int(data['order_index'])
+        sets = int(data['sets'])
+        if order_index < 0: raise ValueError("'order_index' must be non-negative.")
+        if sets < 1: raise ValueError("'sets' must be at least 1.")
+    except (ValueError, TypeError) as e:
+        return jsonify(error=f"Invalid data type or value for required fields: {e}"), 400
+
+    # Optional fields with type validation
+    optional_fields_spec = {
+        'rep_range_low': int, 'rep_range_high': int, 'target_rir': int,
+        'rest_seconds': int, 'notes': str
+    }
+    plan_exercise_data = {}
+    for field, field_type in optional_fields_spec.items():
+        if field in data:
+            value = data[field]
+            if value is not None:
+                try:
+                    typed_value = field_type(value)
+                    # Additional validation for specific fields
+                    if field_type is int and typed_value < 0 and field not in ['target_rir']: # RIR can be negative with some scales/interpretations
+                         raise ValueError(f"'{field}' must be non-negative.")
+                    plan_exercise_data[field] = typed_value
+                except ValueError as e:
+                    return jsonify(error=f"Invalid value for field '{field}': {e}"), 400
+            else:
+                plan_exercise_data[field] = None
+
+
+    conn = None
+    try:
+        conn = get_db_connection()
+        with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            # Verify ownership of the parent plan day (and thus the plan)
+            cur.execute(
+                """
+                SELECT wp.user_id AS plan_owner_id
+                FROM plan_days pd
+                JOIN workout_plans wp ON pd.plan_id = wp.id
+                WHERE pd.id = %s;
+                """, (str(day_id),)
+            )
+            owner_info = cur.fetchone()
+
+            if not owner_info:
+                return jsonify(error="Parent plan day not found"), 404
+
+            if owner_info['plan_owner_id'] != uuid.UUID(g.current_user_id):
+                logger.warning(f"Forbidden attempt to add exercise to day {day_id} by user {g.current_user_id}")
+                return jsonify(error="Forbidden. You do not own the parent plan of this day."), 403
+
+            # Check if exercise_id exists in exercises table
+            cur.execute("SELECT id FROM exercises WHERE id = %s;", (exercise_id,))
+            if not cur.fetchone():
+                return jsonify(error=f"Exercise with id {exercise_id} not found."), 404 # Or 400 Bad Request
+
+            # Check for order_index conflict within the same plan_day
+            cur.execute(
+                "SELECT id FROM plan_exercises WHERE plan_day_id = %s AND order_index = %s;",
+                (str(day_id), order_index)
+            )
+            if cur.fetchone():
+                return jsonify(error=f"An exercise with order_index {order_index} already exists for this day."), 409
+
+            plan_exercise_id = str(uuid.uuid4())
+            insert_query_cols = [
+                'id', 'plan_day_id', 'exercise_id', 'order_index', 'sets',
+                'rep_range_low', 'rep_range_high', 'target_rir', 'rest_seconds', 'notes',
+                'created_at', 'updated_at'
+            ]
+            insert_query_values = [
+                plan_exercise_id, str(day_id), exercise_id, order_index, sets,
+                plan_exercise_data.get('rep_range_low'), plan_exercise_data.get('rep_range_high'),
+                plan_exercise_data.get('target_rir'), plan_exercise_data.get('rest_seconds'),
+                plan_exercise_data.get('notes'),
+                psycopg2.extensions.AsIs('NOW()'), psycopg2.extensions.AsIs('NOW()')
+            ]
+
+            placeholders = ', '.join(['%s'] * len(insert_query_cols))
+            cols_sql = ', '.join(insert_query_cols)
+
+            cur.execute(
+                f"INSERT INTO plan_exercises ({cols_sql}) VALUES ({placeholders}) RETURNING *;",
+                tuple(insert_query_values)
+            )
+            new_plan_exercise = cur.fetchone()
+            conn.commit()
+            logger.info(f"Plan exercise {plan_exercise_id} created for day {day_id} by user {g.current_user_id}")
+            return jsonify(new_plan_exercise), 201
+
+    except psycopg2.Error as e:
+        logger.error(f"Database error creating plan exercise for day {day_id}: {e}")
+        if conn:
+            conn.rollback()
+        return jsonify(error="Database operation failed creating plan exercise"), 500
+    except Exception as e:
+        logger.error(f"Unexpected error creating plan exercise for day {day_id}: {e}", exc_info=True)
+        if conn:
+            conn.rollback()
+        return jsonify(error="An unexpected error occurred creating plan exercise"), 500
+    finally:
+        if conn:
+            conn.close()
+
+@app.route('/v1/plandays/<uuid:day_id>/exercises', methods=['GET'])
+@jwt_required
+def get_plan_exercises_for_day(day_id):
+    from flask import g
+    conn = None
+    try:
+        conn = get_db_connection()
+        with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            # Verify ownership of the parent plan day
+            cur.execute(
+                """
+                SELECT wp.user_id AS plan_owner_id
+                FROM plan_days pd
+                JOIN workout_plans wp ON pd.plan_id = wp.id
+                WHERE pd.id = %s;
+                """, (str(day_id),)
+            )
+            owner_info = cur.fetchone()
+
+            if not owner_info:
+                return jsonify(error="Parent plan day not found"), 404
+
+            if owner_info['plan_owner_id'] != uuid.UUID(g.current_user_id):
+                logger.warning(f"Forbidden attempt to get exercises for day {day_id} by user {g.current_user_id}")
+                return jsonify(error="Forbidden. You do not own the parent plan of this day."), 403
+
+            # Fetch all plan exercises for this day, joining with exercises table for names
+            cur.execute(
+                """
+                SELECT pe.*, e.name as exercise_name
+                FROM plan_exercises pe
+                JOIN exercises e ON pe.exercise_id = e.id
+                WHERE pe.plan_day_id = %s
+                ORDER BY pe.order_index ASC;
+                """,
+                (str(day_id),)
+            )
+            plan_exercises_list = cur.fetchall()
+
+            return jsonify(plan_exercises_list), 200
+
+    except psycopg2.Error as e:
+        logger.error(f"Database error fetching plan exercises for day {day_id}: {e}")
+        return jsonify(error="Database operation failed fetching plan exercises"), 500
+    except Exception as e:
+        logger.error(f"Unexpected error fetching plan exercises for day {day_id}: {e}", exc_info=True)
+        return jsonify(error="An unexpected error occurred fetching plan exercises"), 500
+    finally:
+        if conn:
+            conn.close()
+
+@app.route('/v1/planexercises/<uuid:plan_exercise_id>', methods=['PUT'])
+@jwt_required
+def update_plan_exercise(plan_exercise_id):
+    from flask import g
+    data = request.get_json()
+    if not data:
+        return jsonify(error="Request body must be JSON"), 400
+
+    conn = None
+    try:
+        conn = get_db_connection()
+        with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            # Verify ownership by fetching the plan exercise and joining up to the workout_plan's user_id
+            cur.execute(
+                """
+                SELECT pe.id AS plan_exercise_id, pe.plan_day_id, pd.plan_id, wp.user_id AS plan_owner_id
+                FROM plan_exercises pe
+                JOIN plan_days pd ON pe.plan_day_id = pd.id
+                JOIN workout_plans wp ON pd.plan_id = wp.id
+                WHERE pe.id = %s;
+                """, (str(plan_exercise_id),)
+            )
+            exercise_info = cur.fetchone()
+
+            if not exercise_info:
+                return jsonify(error="Plan exercise not found"), 404
+
+            if exercise_info['plan_owner_id'] != uuid.UUID(g.current_user_id):
+                logger.warning(f"Forbidden attempt to update plan exercise {plan_exercise_id} by user {g.current_user_id}")
+                return jsonify(error="Forbidden. You do not own the parent plan of this exercise."), 403
+
+            # Fields that can be updated
+            allowed_fields = {
+                'exercise_id': uuid.UUID, 'order_index': int, 'sets': int,
+                'rep_range_low': int, 'rep_range_high': int, 'target_rir': int,
+                'rest_seconds': int, 'notes': str
+            }
+
+            update_fields_parts = []
+            update_values = []
+
+            for field, field_type in allowed_fields.items():
+                if field in data:
+                    value = data[field]
+                    if value is None: # Allow nullification for optional fields
+                        if field not in ['exercise_id', 'order_index', 'sets']: # These are usually required
+                            update_fields_parts.append(f"{field} = NULL")
+                            # No value to add to update_values for NULL assignment like this
+                            continue # Skip to next field
+                        else:
+                             return jsonify(error=f"Field '{field}' cannot be null."), 400
+
+                    try:
+                        if field_type is uuid.UUID:
+                            typed_value = str(uuid.UUID(value)) # Validate and convert to string for query
+                            # Check if new exercise_id exists
+                            cur.execute("SELECT id FROM exercises WHERE id = %s;", (typed_value,))
+                            if not cur.fetchone():
+                                return jsonify(error=f"New exercise_id {typed_value} not found."), 400
+                        elif field_type is int:
+                            typed_value = int(value)
+                            if typed_value < 0 and field not in ['target_rir']:
+                                raise ValueError(f"'{field}' must be non-negative.")
+                            if field == 'sets' and typed_value < 1:
+                                raise ValueError("'sets' must be at least 1.")
+                        elif field_type is str:
+                            typed_value = str(value)
+                        else:
+                            typed_value = value # Should not happen with current spec
+
+                        # Check for order_index conflict if it's being changed
+                        if field == 'order_index':
+                            cur.execute(
+                                "SELECT id FROM plan_exercises WHERE plan_day_id = %s AND order_index = %s AND id != %s;",
+                                (exercise_info['plan_day_id'], typed_value, str(plan_exercise_id))
+                            )
+                            if cur.fetchone():
+                                return jsonify(error=f"An exercise with order_index {typed_value} already exists for this day."), 409
+
+                        update_fields_parts.append(f"{field} = %s")
+                        update_values.append(typed_value)
+                    except ValueError as e:
+                        return jsonify(error=f"Invalid value or type for field '{field}': {e}"), 400
+
+            if not update_fields_parts:
+                return jsonify(error="No valid fields provided for update"), 400
+
+            update_fields_parts.append("updated_at = NOW()")
+            query = f"UPDATE plan_exercises SET {', '.join(update_fields_parts)} WHERE id = %s RETURNING *;"
+            update_values.append(str(plan_exercise_id))
+
+            cur.execute(query, tuple(update_values))
+            updated_plan_exercise = cur.fetchone()
+            conn.commit()
+
+            logger.info(f"Plan exercise {plan_exercise_id} updated successfully by user {g.current_user_id}")
+            # Join with exercises table to get exercise_name for the response
+            cur.execute("SELECT name FROM exercises WHERE id = %s;", (updated_plan_exercise['exercise_id'],))
+            exercise_details = cur.fetchone()
+            if exercise_details:
+                 updated_plan_exercise['exercise_name'] = exercise_details['name']
+
+            return jsonify(updated_plan_exercise), 200
+
+    except psycopg2.Error as e:
+        logger.error(f"Database error updating plan exercise {plan_exercise_id}: {e}")
+        if conn:
+            conn.rollback()
+        return jsonify(error="Database operation failed updating plan exercise"), 500
+    except Exception as e:
+        logger.error(f"Unexpected error updating plan exercise {plan_exercise_id}: {e}", exc_info=True)
+        if conn:
+            conn.rollback()
+        return jsonify(error="An unexpected error occurred updating plan exercise"), 500
+    finally:
+        if conn:
+            conn.close()
+
+@app.route('/v1/planexercises/<uuid:plan_exercise_id>', methods=['DELETE'])
+@jwt_required
+def delete_plan_exercise(plan_exercise_id):
+    from flask import g
+    conn = None
+    try:
+        conn = get_db_connection()
+        with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            # Verify ownership by fetching the plan exercise and joining up to the workout_plan's user_id
+            cur.execute(
+                """
+                SELECT wp.user_id AS plan_owner_id
+                FROM plan_exercises pe
+                JOIN plan_days pd ON pe.plan_day_id = pd.id
+                JOIN workout_plans wp ON pd.plan_id = wp.id
+                WHERE pe.id = %s;
+                """, (str(plan_exercise_id),)
+            )
+            exercise_info = cur.fetchone()
+
+            if not exercise_info:
+                return jsonify(error="Plan exercise not found"), 404
+
+            if exercise_info['plan_owner_id'] != uuid.UUID(g.current_user_id):
+                logger.warning(f"Forbidden attempt to delete plan exercise {plan_exercise_id} by user {g.current_user_id}")
+                return jsonify(error="Forbidden. You do not own the parent plan of this exercise."), 403
+
+            # Delete the plan exercise
+            cur.execute("DELETE FROM plan_exercises WHERE id = %s;", (str(plan_exercise_id),))
+            conn.commit()
+
+            if cur.rowcount == 0:
+                # Should be caught by the initial check, but as a safeguard
+                logger.error(f"Failed to delete plan exercise {plan_exercise_id}, though ownership was verified. Exercise might have been deleted by another process.")
+                return jsonify(error="Failed to delete plan exercise, it might have already been deleted."), 404
+
+            logger.info(f"Plan exercise {plan_exercise_id} deleted successfully by user {g.current_user_id}")
+            return '', 204
+
+    except psycopg2.Error as e:
+        logger.error(f"Database error deleting plan exercise {plan_exercise_id}: {e}")
+        if conn:
+            conn.rollback()
+        return jsonify(error="Database operation failed deleting plan exercise"), 500
+    except Exception as e:
+        logger.error(f"Unexpected error deleting plan exercise {plan_exercise_id}: {e}", exc_info=True)
+        if conn:
+            conn.rollback()
+        return jsonify(error="An unexpected error occurred deleting plan exercise"), 500
+    finally:
+        if conn:
+            conn.close()
+
 # --- New Webhook Endpoint for Training Pipeline ---
 @app.route('/v1/system/trigger-training-pipeline', methods=['POST'])
 def trigger_training_pipeline_route():
@@ -1127,6 +2004,245 @@ def check_for_plateau_and_suggest_deload(
 
 
     return result
+
+
+if __name__ == '__main__':
+    _conn_check = None
+    try:
+        # Keep existing DB check
+        _conn_check = get_db_connection()
+        with _conn_check.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as _cur:
+            _cur.execute("""
+                SELECT column_name
+                FROM information_schema.columns
+                WHERE table_name='exercises' AND column_name='main_target_muscle_group';
+            """)
+            if not _cur.fetchone():
+                logger.warning("WARNING: The 'exercises' table does not seem to have the "
+                               "'main_target_muscle_group' column assumed by some endpoints. "
+                               "These endpoints may not function correctly for session history.")
+    except Exception as _e:
+        # Log a more general warning if DB connection itself fails here for the check
+        logger.warning(f"Could not perform initial schema check for 'main_target_muscle_group' column (DB might not be ready or accessible for this check): {_e}")
+    finally:
+        if _conn_check:
+            _conn_check.close()
+
+    # --- Test Plateau Detection and Deload Suggestion ---
+    print("\n--- Testing Plateau Detection and Deload Integration ---")
+    test_user_id = "user_test_123"
+    test_exercise_id = "exercise_bench_press"
+
+    scenarios_to_test = [
+        {"name": "Clear Progression", "scenario": "progression", "fatigue": 20.0},
+        {"name": "Stagnation (Moderate Fatigue)", "scenario": "stagnation", "fatigue": 50.0},
+        {"name": "Stagnation (High Fatigue)", "scenario": "stagnation", "fatigue": 75.0},
+        {"name": "Regression", "scenario": "regression", "fatigue": 60.0},
+        {"name": "Short History", "scenario": "short_history", "fatigue": 30.0},
+        {"name": "Volatile Data", "scenario": "volatile", "fatigue": 40.0},
+        {"name": "Initial Gains then Stagnation", "scenario": "initial_gains_then_stagnation", "fatigue": 55.0}
+    ]
+
+    for test_case in scenarios_to_test:
+        print(f"\n--- Scenario: {test_case['name']} (Fatigue: {test_case['fatigue']}) ---")
+        result = check_for_plateau_and_suggest_deload(
+            user_id=test_user_id,
+            exercise_id=test_exercise_id,
+            mock_scenario=test_case["scenario"],
+            mock_fatigue=test_case["fatigue"],
+            plateau_min_duration=5 # Using min_duration of 5 for these tests
+        )
+        # Using pprint for better readability of the dictionary
+        pprint(result, indent=2)
+        print("--------------------------------------------------")
+
+    # Example with directly passed historical data
+    print("\n--- Scenario: Direct Data - Clear Regression ---")
+    direct_data = [110.0, 108.0, 107.5, 106.0, 105.0, 103.0, 102.0]
+    result_direct = check_for_plateau_and_suggest_deload(
+        user_id=test_user_id,
+        exercise_id="exercise_squat",
+        historical_performance_data=direct_data,
+        mock_fatigue=70.0,
+        plateau_min_duration=4 # Test with different min_duration
+    )
+    pprint(result_direct, indent=2)
+    print("--------------------------------------------------")
+
+    # Keep the Flask app run command if this file is also meant to be executable as a server
+    # For subtask testing, the print statements above are the primary output.
+    # If running in a CI/test environment where the Flask app shouldn't start,
+    # you might guard app.run with a specific condition.
+    # For now, assuming it's fine as is.
+    # app.run(host='0.0.0.0', port=5000, debug=True) # Comment out for sequential execution if __main__ is run multiple times
+
+# --- Analytics Dashboard Endpoints ---
+@app.route('/v1/users/<uuid:user_id>/exercises/<uuid:exercise_id>/plateau-analysis', methods=['GET'])
+@jwt_required
+def get_plateau_analysis(user_id, exercise_id):
+    from flask import g
+    from engine.progression import detect_plateau, generate_deload_protocol, PlateauStatus
+    # from engine.learning_models import calculate_current_fatigue, DEFAULT_RECOVERY_TAU_MAP, SessionRecord -> Already imported
+
+    # Authorization
+    if str(user_id) != g.current_user_id:
+        logger.warning(f"Forbidden attempt to access plateau analysis for user {user_id} by user {g.current_user_id}")
+        return jsonify(error="Forbidden. You can only access your own data."), 403
+
+    conn = None
+    try:
+        conn = get_db_connection()
+        with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            # 1. Fetch Exercise Details
+            cur.execute(
+                "SELECT name, main_target_muscle_group FROM exercises WHERE id = %s;",
+                (str(exercise_id),)
+            )
+            exercise_data = cur.fetchone()
+            if not exercise_data:
+                return jsonify(error=f"Exercise with ID {exercise_id} not found."), 404
+            if not exercise_data['main_target_muscle_group']:
+                return jsonify(error=f"Exercise '{exercise_data['name']}' (ID: {exercise_id}) is missing 'main_target_muscle_group' which is required for analysis."), 404
+
+            exercise_name = exercise_data['name']
+            main_target_muscle_group = exercise_data['main_target_muscle_group']
+
+            # 2. Fetch Historical Performance Data (e1RM)
+            cur.execute(
+                """
+                SELECT estimated_1rm, calculated_at FROM estimated_1rm_history
+                WHERE user_id = %s AND exercise_id = %s
+                ORDER BY calculated_at ASC;
+                """,
+                (str(user_id), str(exercise_id))
+            )
+            e1rm_history_records = cur.fetchall()
+
+            historical_e1rms = [float(record['estimated_1rm']) for record in e1rm_history_records]
+            MIN_DATA_POINTS_FOR_PLATEAU = 7 # Configurable minimum for meaningful analysis
+
+            if len(historical_e1rms) < MIN_DATA_POINTS_FOR_PLATEAU:
+                return jsonify({
+                    "user_id": str(user_id),
+                    "exercise_id": str(exercise_id),
+                    "exercise_name": exercise_name,
+                    "main_target_muscle_group": main_target_muscle_group,
+                    "historical_data_points_count": len(historical_e1rms),
+                    "plateau_analysis": None,
+                    "current_fatigue_score": None, # Could still calculate fatigue if desired
+                    "deload_suggested": False,
+                    "deload_protocol": None,
+                    "summary_message": f"Insufficient data for plateau analysis. Need at least {MIN_DATA_POINTS_FOR_PLATEAU} e1RM records."
+                }), 200 # Or 202 Accepted if we want to signify it's not a full analysis
+
+            # 3. Fetch User Fatigue Score (adapting from fatigue_status_route)
+            cur.execute("SELECT recovery_multipliers FROM users WHERE id = %s;", (str(user_id),))
+            user_data_db = cur.fetchone() # User should exist if JWT valid and user_id matches
+            if not user_data_db: # Should ideally not happen due to JWT check
+                logger.error(f"User data not found for user {user_id} despite passing JWT check.")
+                return jsonify(error="User data inconsistency."), 500
+
+            user_recovery_multiplier = 1.0
+            recovery_multipliers_data = user_data_db.get('recovery_multipliers') or {}
+            if isinstance(recovery_multipliers_data, dict):
+                user_recovery_multiplier = float(recovery_multipliers_data.get(main_target_muscle_group, 1.0))
+
+            session_history_query = """
+                SELECT ws.completed_at AS session_date, (ws.actual_weight * ws.actual_reps) AS stimulus
+                FROM workout_sets ws
+                JOIN workouts w ON ws.workout_id = w.id
+                JOIN exercises e ON ws.exercise_id = e.id
+                WHERE w.user_id = %s AND e.main_target_muscle_group = %s
+                  AND ws.completed_at IS NOT NULL AND ws.actual_weight IS NOT NULL AND ws.actual_reps IS NOT NULL
+                ORDER BY ws.completed_at DESC LIMIT 50;
+            """
+            cur.execute(session_history_query, (str(user_id), main_target_muscle_group))
+            raw_session_history = cur.fetchall()
+            session_history_formatted: list[SessionRecord] = []
+            for record in raw_session_history:
+                 if isinstance(record['session_date'], datetime) and \
+                   (isinstance(record['stimulus'], (float, int))):
+                    session_history_formatted.append({
+                        'session_date': record['session_date'],
+                        'stimulus': float(record['stimulus'])
+                    })
+
+            current_fatigue_score = calculate_current_fatigue(
+                main_target_muscle_group,
+                session_history_formatted,
+                DEFAULT_RECOVERY_TAU_MAP, # Make sure this is available in scope
+                user_recovery_multiplier
+            )
+            current_fatigue_score = round(current_fatigue_score, 2)
+
+
+            # 4. Plateau Detection Logic
+            # Using MIN_DATA_POINTS_FOR_PLATEAU as min_duration, or a slightly smaller number if appropriate
+            plateau_min_duration = max(3, MIN_DATA_POINTS_FOR_PLATEAU - 2) # e.g. 5 if MIN_DATA_POINTS_FOR_PLATEAU is 7
+            plateau_result = detect_plateau(
+                values=historical_e1rms,
+                min_duration=plateau_min_duration
+            )
+
+            # 5. Deload Protocol Generation
+            deload_suggested = False
+            deload_protocol = None
+            summary_message = f"Analysis complete for {exercise_name}."
+
+            if plateau_result['plateauing']:
+                deload_suggested = True
+                plateau_severity = 0.0
+                if plateau_result['status'] == PlateauStatus.REGRESSION:
+                    plateau_severity = 0.8
+                    summary_message = f"Regression detected for {exercise_name}. A deload is recommended."
+                elif plateau_result['status'] == PlateauStatus.STAGNATION:
+                    plateau_severity = 0.5
+                    summary_message = f"Stagnation detected for {exercise_name}. Consider a deload."
+                elif plateau_result['status'] in [PlateauStatus.REGRESSION_WARNING, PlateauStatus.STAGNATION_WARNING]:
+                    plateau_severity = 0.3 # Mild warning, might not always trigger deload by default
+                    summary_message = f"Warning of potential {plateau_result['status'].name.lower().replace('_warning','')} for {exercise_name}."
+                    # Optional: Only suggest deload for stronger signals
+                    if plateau_severity < 0.4: # Example threshold
+                        deload_suggested = False
+
+
+                if deload_suggested:
+                    deload_duration_weeks = 1 # Default duration
+                    if plateau_severity >= 0.7: # Stronger regression
+                        deload_duration_weeks = 2
+
+                    deload_protocol = generate_deload_protocol(
+                        plateau_severity=plateau_severity,
+                        deload_duration_weeks=deload_duration_weeks,
+                        recent_fatigue_score=current_fatigue_score
+                    )
+            else:
+                summary_message = f"No significant plateau detected for {exercise_name} based on the last {len(historical_e1rms)} records."
+
+
+            # 6. Response Formatting
+            return jsonify({
+                "user_id": str(user_id),
+                "exercise_id": str(exercise_id),
+                "exercise_name": exercise_name,
+                "main_target_muscle_group": main_target_muscle_group,
+                "historical_data_points_count": len(historical_e1rms),
+                "plateau_analysis": plateau_result,
+                "current_fatigue_score": current_fatigue_score,
+                "deload_suggested": deload_suggested,
+                "deload_protocol": deload_protocol,
+                "summary_message": summary_message
+            }), 200
+
+    except psycopg2.Error as e:
+        logger.error(f"Database error during plateau analysis for user {user_id}, exercise {exercise_id}: {e}", exc_info=True)
+        return jsonify(error="Database operation failed during analysis."), 500
+    except Exception as e:
+        logger.error(f"Unexpected error during plateau analysis for user {user_id}, exercise {exercise_id}: {e}", exc_info=True)
+        return jsonify(error="An unexpected error occurred during analysis."), 500
+    finally:
+        if conn:
+            conn.close()
 
 
 if __name__ == '__main__':

--- a/tests/test_analytics_api.py
+++ b/tests/test_analytics_api.py
@@ -1,0 +1,335 @@
+import pytest
+import json
+import uuid
+import datetime
+from unittest.mock import patch, MagicMock, ANY # ANY is useful for some mock assertions
+
+import psycopg2 # For explicitly raising psycopg2.Error in tests
+
+# Import the Flask app from engine.app
+from engine.app import app
+# Assuming PlateauStatus is accessible for mocking detect_plateau results
+from engine.progression import PlateauStatus
+
+# --- Test Fixtures ---
+
+@pytest.fixture
+def client():
+    """A test client for the app."""
+    with app.app_context():
+        app.config['TESTING'] = True
+        # app.config['JWT_SECRET_KEY'] = 'test-secret-key' # Ensure this is consistent if not using app's default
+        client = app.test_client()
+        yield client
+
+# --- Helper Functions ---
+
+def generate_jwt_token(user_id, secret_key=None):
+    """Generates a JWT token for a given user_id."""
+    import jwt
+    if secret_key is None:
+        secret_key = app.config['JWT_SECRET_KEY']
+
+    payload = {
+        'user_id': str(user_id),
+        'exp': datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(hours=1)
+    }
+    token = jwt.encode(payload, secret_key, algorithm="HS256")
+    return token
+
+# --- Mock Data ---
+MOCK_USER_ID = str(uuid.uuid4())
+MOCK_OTHER_USER_ID = str(uuid.uuid4())
+MOCK_EXERCISE_ID = str(uuid.uuid4())
+MOCK_EXERCISE_NAME = "Test Bench Press"
+MOCK_MUSCLE_GROUP = "chest"
+
+# --- Test Cases for Plateau Analysis Endpoint ---
+
+@patch('engine.app.generate_deload_protocol')
+@patch('engine.app.detect_plateau')
+@patch('engine.app.calculate_current_fatigue')
+@patch('engine.app.get_db_connection')
+def test_get_plateau_analysis_success_no_plateau(
+    mock_get_db_conn, mock_calc_fatigue, mock_detect_plateau, mock_gen_deload, client
+):
+    # Setup Mocks
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_get_db_conn.return_value = mock_conn
+    mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+
+    # DB Mocks
+    mock_cursor.fetchone.side_effect = [
+        {'name': MOCK_EXERCISE_NAME, 'main_target_muscle_group': MOCK_MUSCLE_GROUP}, # Exercise details
+        {'recovery_multipliers': {MOCK_MUSCLE_GROUP: 1.0}} # User recovery multipliers
+    ]
+    mock_cursor.fetchall.side_effect = [
+        [{'estimated_1rm': 100.0 + i} for i in range(10)], # e1RM history (10 data points)
+        [] # Session history for fatigue (empty for simplicity here)
+    ]
+
+    mock_calc_fatigue.return_value = 15.0 # Low fatigue
+    mock_detect_plateau.return_value = {'plateauing': False, 'status': PlateauStatus.NO_PLATEAU, 'slope': 0.5}
+
+    token = generate_jwt_token(MOCK_USER_ID)
+    response = client.get(
+        f'/v1/users/{MOCK_USER_ID}/exercises/{MOCK_EXERCISE_ID}/plateau-analysis',
+        headers={'Authorization': f'Bearer {token}'}
+    )
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data['exercise_name'] == MOCK_EXERCISE_NAME
+    assert data['historical_data_points_count'] == 10
+    assert data['plateau_analysis']['plateauing'] is False
+    assert data['plateau_analysis']['status'] == PlateauStatus.NO_PLATEAU.name # Enum is serialized to name
+    assert data['current_fatigue_score'] == 15.0
+    assert data['deload_suggested'] is False
+    assert data['deload_protocol'] is None
+    mock_gen_deload.assert_not_called()
+    mock_detect_plateau.assert_called_once()
+
+
+@patch('engine.app.generate_deload_protocol')
+@patch('engine.app.detect_plateau')
+@patch('engine.app.calculate_current_fatigue')
+@patch('engine.app.get_db_connection')
+def test_get_plateau_analysis_success_stagnation_with_deload(
+    mock_get_db_conn, mock_calc_fatigue, mock_detect_plateau, mock_gen_deload, client
+):
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_get_db_conn.return_value = mock_conn
+    mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+
+    mock_cursor.fetchone.side_effect = [
+        {'name': MOCK_EXERCISE_NAME, 'main_target_muscle_group': MOCK_MUSCLE_GROUP},
+        {'recovery_multipliers': {}}
+    ]
+    mock_cursor.fetchall.side_effect = [
+        [{'estimated_1rm': 100.0} for _ in range(10)], # Stagnant e1RM history
+        []
+    ]
+
+    mock_calc_fatigue.return_value = 40.0 # Moderate fatigue
+    mock_detect_plateau.return_value = {'plateauing': True, 'status': PlateauStatus.STAGNATION, 'slope': 0.05}
+    mock_gen_deload.return_value = [{'week': 1, 'instruction': 'Reduce volume by 20%'}]
+
+    token = generate_jwt_token(MOCK_USER_ID)
+    response = client.get(
+        f'/v1/users/{MOCK_USER_ID}/exercises/{MOCK_EXERCISE_ID}/plateau-analysis',
+        headers={'Authorization': f'Bearer {token}'}
+    )
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data['plateau_analysis']['plateauing'] is True
+    assert data['plateau_analysis']['status'] == PlateauStatus.STAGNATION.name
+    assert data['current_fatigue_score'] == 40.0
+    assert data['deload_suggested'] is True
+    assert len(data['deload_protocol']) == 1
+    assert data['deload_protocol'][0]['instruction'] == 'Reduce volume by 20%'
+    mock_gen_deload.assert_called_once_with(
+        plateau_severity=0.5, # Expected for STAGNATION
+        deload_duration_weeks=ANY, # or specific value if you want to be more precise
+        recent_fatigue_score=40.0
+    )
+
+@patch('engine.app.generate_deload_protocol')
+@patch('engine.app.detect_plateau')
+@patch('engine.app.calculate_current_fatigue')
+@patch('engine.app.get_db_connection')
+def test_get_plateau_analysis_success_regression_with_deload(
+    mock_get_db_conn, mock_calc_fatigue, mock_detect_plateau, mock_gen_deload, client
+):
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_get_db_conn.return_value = mock_conn
+    mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+
+    mock_cursor.fetchone.side_effect = [
+        {'name': MOCK_EXERCISE_NAME, 'main_target_muscle_group': MOCK_MUSCLE_GROUP},
+        {'recovery_multipliers': {}}
+    ]
+    mock_cursor.fetchall.side_effect = [
+        [{'estimated_1rm': 100.0 - i} for i in range(10)], # Regressing e1RM history
+        []
+    ]
+
+    mock_calc_fatigue.return_value = 60.0 # High fatigue
+    mock_detect_plateau.return_value = {'plateauing': True, 'status': PlateauStatus.REGRESSION, 'slope': -0.5}
+    mock_gen_deload.return_value = [{'week': 1, 'instruction': 'Reduce intensity significantly'}]
+
+    token = generate_jwt_token(MOCK_USER_ID)
+    response = client.get(
+        f'/v1/users/{MOCK_USER_ID}/exercises/{MOCK_EXERCISE_ID}/plateau-analysis',
+        headers={'Authorization': f'Bearer {token}'}
+    )
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data['plateau_analysis']['plateauing'] is True
+    assert data['plateau_analysis']['status'] == PlateauStatus.REGRESSION.name
+    assert data['deload_suggested'] is True
+    assert data['deload_protocol'][0]['instruction'] == 'Reduce intensity significantly'
+    mock_gen_deload.assert_called_once_with(
+        plateau_severity=0.8, # Expected for REGRESSION
+        deload_duration_weeks=ANY,
+        recent_fatigue_score=60.0
+    )
+
+@patch('engine.app.get_db_connection') # Only need to mock DB for this one
+def test_get_plateau_analysis_insufficient_data(mock_get_db_conn, client):
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_get_db_conn.return_value = mock_conn
+    mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+
+    mock_cursor.fetchone.return_value = {'name': MOCK_EXERCISE_NAME, 'main_target_muscle_group': MOCK_MUSCLE_GROUP}
+    mock_cursor.fetchall.return_value = [{'estimated_1rm': 100.0} for _ in range(3)] # Only 3 data points
+
+    token = generate_jwt_token(MOCK_USER_ID)
+    response = client.get(
+        f'/v1/users/{MOCK_USER_ID}/exercises/{MOCK_EXERCISE_ID}/plateau-analysis',
+        headers={'Authorization': f'Bearer {token}'}
+    )
+
+    assert response.status_code == 200 # Endpoint returns 200 with a message
+    data = response.get_json()
+    assert "Insufficient data for plateau analysis" in data['summary_message']
+    assert data['historical_data_points_count'] == 3
+    assert data['plateau_analysis'] is None
+    assert data['deload_suggested'] is False
+
+def test_get_plateau_analysis_unauthorized_missing_token(client):
+    response = client.get(f'/v1/users/{MOCK_USER_ID}/exercises/{MOCK_EXERCISE_ID}/plateau-analysis')
+    assert response.status_code == 401
+
+def test_get_plateau_analysis_forbidden_wrong_user(client):
+    token = generate_jwt_token(MOCK_OTHER_USER_ID) # Token for other user
+    response = client.get(
+        f'/v1/users/{MOCK_USER_ID}/exercises/{MOCK_EXERCISE_ID}/plateau-analysis', # Requesting for MOCK_USER_ID
+        headers={'Authorization': f'Bearer {token}'}
+    )
+    assert response.status_code == 403
+
+@patch('engine.app.get_db_connection')
+def test_get_plateau_analysis_exercise_not_found(mock_get_db_conn, client):
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_get_db_conn.return_value = mock_conn
+    mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+    mock_cursor.fetchone.return_value = None # Simulate exercise not found
+
+    token = generate_jwt_token(MOCK_USER_ID)
+    response = client.get(
+        f'/v1/users/{MOCK_USER_ID}/exercises/{MOCK_EXERCISE_ID}/plateau-analysis',
+        headers={'Authorization': f'Bearer {token}'}
+    )
+    assert response.status_code == 404
+    assert f"Exercise with ID {MOCK_EXERCISE_ID} not found" in response.get_json()['error']
+
+@patch('engine.app.get_db_connection')
+def test_get_plateau_analysis_exercise_no_main_target_muscle_group(mock_get_db_conn, client):
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_get_db_conn.return_value = mock_conn
+    mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+    mock_cursor.fetchone.return_value = {'name': MOCK_EXERCISE_NAME, 'main_target_muscle_group': None}
+
+    token = generate_jwt_token(MOCK_USER_ID)
+    response = client.get(
+        f'/v1/users/{MOCK_USER_ID}/exercises/{MOCK_EXERCISE_ID}/plateau-analysis',
+        headers={'Authorization': f'Bearer {token}'}
+    )
+    assert response.status_code == 404
+    assert f"is missing 'main_target_muscle_group'" in response.get_json()['error']
+
+@patch('engine.app.get_db_connection')
+def test_get_plateau_analysis_db_error_exercise_fetch(mock_get_db_conn, client):
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_get_db_conn.return_value = mock_conn
+    mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+    # Simulate DB error when fetching exercise details
+    mock_cursor.execute.side_effect = lambda query, params: psycopg2.Error("Simulated DB error") if "FROM exercises WHERE id = %s" in query else MagicMock()
+
+    token = generate_jwt_token(MOCK_USER_ID)
+    response = client.get(
+        f'/v1/users/{MOCK_USER_ID}/exercises/{MOCK_EXERCISE_ID}/plateau-analysis',
+        headers={'Authorization': f'Bearer {token}'}
+    )
+    assert response.status_code == 500
+    assert "Database operation failed" in response.get_json()['error']
+
+@patch('engine.app.get_db_connection')
+def test_get_plateau_analysis_db_error_1rm_history_fetch(mock_get_db_conn, client):
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_get_db_conn.return_value = mock_conn
+    mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+
+    # First call (exercise details) is fine
+    mock_cursor.fetchone.return_value = {'name': MOCK_EXERCISE_NAME, 'main_target_muscle_group': MOCK_MUSCLE_GROUP}
+    # Second execute call (e1RM history) raises error
+    def conditional_execute_effect(query, params):
+        if "FROM estimated_1rm_history" in query:
+            raise psycopg2.Error("Simulated DB error on e1RM fetch")
+        return MagicMock() # Default for other execute calls
+    mock_cursor.execute.side_effect = conditional_execute_effect
+
+    token = generate_jwt_token(MOCK_USER_ID)
+    response = client.get(
+        f'/v1/users/{MOCK_USER_ID}/exercises/{MOCK_EXERCISE_ID}/plateau-analysis',
+        headers={'Authorization': f'Bearer {token}'}
+    )
+    assert response.status_code == 500
+    assert "Database operation failed" in response.get_json()['error']
+
+
+@patch('engine.app.get_db_connection')
+def test_get_plateau_analysis_db_error_fatigue_calc_related_fetch(mock_get_db_conn, client):
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_get_db_conn.return_value = mock_conn
+    mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+
+    # First execute (exercise details) and fetchall (e1RM history) are fine
+    mock_cursor.fetchone.side_effect = [
+        {'name': MOCK_EXERCISE_NAME, 'main_target_muscle_group': MOCK_MUSCLE_GROUP}, # Exercise details
+        # No more fetchone needed until after the failing execute
+    ]
+    mock_cursor.fetchall.return_value = [{'estimated_1rm': 100.0 + i} for i in range(10)] # e1RM history
+
+    # Third execute call (user recovery multipliers) raises error
+    def conditional_execute_effect(query, params):
+        if "FROM users WHERE id = %s" in query: # This is for recovery_multipliers
+            raise psycopg2.Error("Simulated DB error on fatigue data fetch")
+        return MagicMock()
+
+    # Need to ensure the first execute for exercise details doesn't use this side_effect
+    original_execute = mock_cursor.execute # Store original
+    def side_effect_router(query, params=None): # Params might be None for some calls
+        if "FROM exercises WHERE id = %s" in query:
+            return original_execute(query, params)
+        elif "FROM estimated_1rm_history" in query:
+            return original_execute(query, params)
+        elif "FROM users WHERE id = %s" in query:
+            raise psycopg2.Error("Simulated DB error on fatigue data fetch")
+        elif "FROM workout_sets ws" in query: # Could also fail here
+             raise psycopg2.Error("Simulated DB error on fatigue data fetch")
+        return original_execute(query,params)
+
+    mock_cursor.execute.side_effect = side_effect_router
+
+    token = generate_jwt_token(MOCK_USER_ID)
+    response = client.get(
+        f'/v1/users/{MOCK_USER_ID}/exercises/{MOCK_EXERCISE_ID}/plateau-analysis',
+        headers={'Authorization': f'Bearer {token}'}
+    )
+    assert response.status_code == 500
+    assert "Database operation failed" in response.get_json()['error']
+
+if __name__ == '__main__':
+    pytest.main()

--- a/tests/test_plan_builder_api.py
+++ b/tests/test_plan_builder_api.py
@@ -1,0 +1,928 @@
+import pytest
+import json
+import uuid
+from unittest.mock import patch, MagicMock
+
+# Import the Flask app from engine.app
+# Ensure that engine/app.py can be imported. This might require adjusting PYTHONPATH or project structure.
+# For this example, assuming 'engine' is a package and app.py is in it.
+from engine.app import app
+
+# --- Test Fixtures ---
+
+@pytest.fixture
+def client():
+    """A test client for the app."""
+    with app.app_context(): # Ensure app context is active for tests
+        app.config['TESTING'] = True
+        # Use a fixed JWT secret for testing if your app.config['JWT_SECRET_KEY'] is dynamic
+        # app.config['JWT_SECRET_KEY'] = 'test-secret-key'
+        client = app.test_client()
+        yield client
+
+# --- Helper Functions ---
+
+def generate_jwt_token(user_id, secret_key=None):
+    """Generates a JWT token for a given user_id."""
+    import jwt
+    import datetime
+    if secret_key is None:
+        secret_key = app.config['JWT_SECRET_KEY'] # Use app's configured key
+
+    payload = {
+        'user_id': str(user_id),
+        'exp': datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(hours=1)
+    }
+    token = jwt.encode(payload, secret_key, algorithm="HS256")
+    return token
+
+# --- Mock Data ---
+MOCK_USER_ID = str(uuid.uuid4())
+MOCK_OTHER_USER_ID = str(uuid.uuid4())
+MOCK_PLAN_ID = str(uuid.uuid4())
+MOCK_DAY_ID = str(uuid.uuid4())
+MOCK_EXERCISE_ID_DB = str(uuid.uuid4()) # An exercise ID that exists in the mocked DB
+MOCK_PLAN_EXERCISE_ID = str(uuid.uuid4())
+
+
+# --- Test Cases for Workout Plan Endpoints ---
+
+@patch('engine.app.get_db_connection')
+def test_create_workout_plan_success(mock_get_db_conn, client):
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_get_db_conn.return_value = mock_conn
+    mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+
+    # Mock DB returning the new plan
+    mock_plan_data = {
+        'id': MOCK_PLAN_ID,
+        'user_id': MOCK_USER_ID,
+        'name': 'My New Plan',
+        'days_per_week': 3,
+        'plan_length_weeks': 4,
+        'goal_focus': 'hypertrophy',
+        'created_at': '2023-01-01T10:00:00Z',
+        'updated_at': '2023-01-01T10:00:00Z'
+    }
+    mock_cursor.fetchone.return_value = mock_plan_data
+
+    token = generate_jwt_token(MOCK_USER_ID)
+    response = client.post(
+        f'/v1/users/{MOCK_USER_ID}/plans',
+        headers={'Authorization': f'Bearer {token}'},
+        json={'name': 'My New Plan', 'days_per_week': 3, 'plan_length_weeks': 4, 'goal_focus': 'hypertrophy'}
+    )
+
+    assert response.status_code == 201
+    response_data = response.get_json()
+    assert response_data['name'] == 'My New Plan'
+    assert response_data['user_id'] == MOCK_USER_ID
+    mock_cursor.execute.assert_called_once() # Simplified check, could be more specific
+
+@patch('engine.app.get_db_connection')
+def test_create_workout_plan_unauthorized_no_token(mock_get_db_conn, client):
+    response = client.post(
+        f'/v1/users/{MOCK_USER_ID}/plans',
+        json={'name': 'My New Plan'}
+    )
+    assert response.status_code == 401
+    assert 'token is missing' in response.get_json()['message'].lower()
+
+@patch('engine.app.get_db_connection')
+def test_create_workout_plan_forbidden_wrong_user(mock_get_db_conn, client):
+    token = generate_jwt_token(MOCK_OTHER_USER_ID) # Token for a different user
+    response = client.post(
+        f'/v1/users/{MOCK_USER_ID}/plans', # Path for MOCK_USER_ID
+        headers={'Authorization': f'Bearer {token}'},
+        json={'name': 'My New Plan'}
+    )
+    assert response.status_code == 403
+    assert 'only create plans for your own profile' in response.get_json()['error'].lower()
+
+@patch('engine.app.get_db_connection')
+def test_create_workout_plan_bad_request_missing_name(mock_get_db_conn, client):
+    token = generate_jwt_token(MOCK_USER_ID)
+    response = client.post(
+        f'/v1/users/{MOCK_USER_ID}/plans',
+        headers={'Authorization': f'Bearer {token}'},
+        json={'days_per_week': 3} # Missing 'name'
+    )
+    assert response.status_code == 400
+    assert 'missing required field: name' in response.get_json()['error'].lower()
+
+@patch('engine.app.get_db_connection')
+def test_get_workout_plans_for_user_success(mock_get_db_conn, client):
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_get_db_conn.return_value = mock_conn
+    mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+
+    mock_plans_list = [
+        {'id': MOCK_PLAN_ID, 'user_id': MOCK_USER_ID, 'name': 'Plan 1'},
+        {'id': str(uuid.uuid4()), 'user_id': MOCK_USER_ID, 'name': 'Plan 2'}
+    ]
+    mock_cursor.fetchall.return_value = mock_plans_list
+
+    token = generate_jwt_token(MOCK_USER_ID)
+    response = client.get(
+        f'/v1/users/{MOCK_USER_ID}/plans',
+        headers={'Authorization': f'Bearer {token}'}
+    )
+
+    assert response.status_code == 200
+    response_data = response.get_json()
+    assert len(response_data) == 2
+    assert response_data[0]['name'] == 'Plan 1'
+
+@patch('engine.app.get_db_connection')
+def test_get_specific_workout_plan_success(mock_get_db_conn, client):
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_get_db_conn.return_value = mock_conn
+    mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+
+    mock_plan_details = {
+        'id': MOCK_PLAN_ID,
+        'user_id': uuid.UUID(MOCK_USER_ID), # Ensure UUID type for comparison in endpoint
+        'name': 'Detailed Plan',
+        'days': [] # Simplified, real endpoint populates this
+    }
+    # Simulate multiple fetchone/fetchall calls for plan, days, exercises
+    mock_cursor.fetchone.side_effect = [
+        mock_plan_details, # First call for the plan itself
+        # Potentially more if days/exercises were deeply mocked here
+    ]
+    mock_cursor.fetchall.side_effect = [
+        [], # For plan_days
+        # Potentially more if exercises were fetched per day
+    ]
+
+
+    token = generate_jwt_token(MOCK_USER_ID)
+    response = client.get(
+        f'/v1/plans/{MOCK_PLAN_ID}',
+        headers={'Authorization': f'Bearer {token}'}
+    )
+    assert response.status_code == 200
+    response_data = response.get_json()
+    assert response_data['name'] == 'Detailed Plan'
+    assert response_data['id'] == MOCK_PLAN_ID
+    # In a more detailed test, assert structure of 'days' and their 'exercises'
+
+@patch('engine.app.get_db_connection')
+def test_get_specific_workout_plan_not_found(mock_get_db_conn, client):
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_get_db_conn.return_value = mock_conn
+    mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+    mock_cursor.fetchone.return_value = None # Plan not found
+
+    token = generate_jwt_token(MOCK_USER_ID)
+    response = client.get(
+        f'/v1/plans/{str(uuid.uuid4())}', # Non-existent plan ID
+        headers={'Authorization': f'Bearer {token}'}
+    )
+    assert response.status_code == 404
+    assert 'plan not found' in response.get_json()['error'].lower()
+
+@patch('engine.app.get_db_connection')
+def test_get_specific_workout_plan_forbidden(mock_get_db_conn, client):
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_get_db_conn.return_value = mock_conn
+    mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+
+    # Plan exists but belongs to MOCK_OTHER_USER_ID
+    mock_plan_details = {'id': MOCK_PLAN_ID, 'user_id': uuid.UUID(MOCK_OTHER_USER_ID), 'name': 'Other User Plan'}
+    mock_cursor.fetchone.return_value = mock_plan_details
+
+    token = generate_jwt_token(MOCK_USER_ID) # Current user is MOCK_USER_ID
+    response = client.get(
+        f'/v1/plans/{MOCK_PLAN_ID}',
+        headers={'Authorization': f'Bearer {token}'}
+    )
+    assert response.status_code == 403
+    assert 'you do not own this plan' in response.get_json()['error'].lower()
+
+@patch('engine.app.get_db_connection')
+def test_update_workout_plan_success(mock_get_db_conn, client):
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_get_db_conn.return_value = mock_conn
+    mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+
+    # Mock fetching owner and then the updated plan
+    mock_owner_check = {'user_id': uuid.UUID(MOCK_USER_ID)}
+    updated_plan_data = {'id': MOCK_PLAN_ID, 'user_id': MOCK_USER_ID, 'name': 'Updated Plan Name'}
+    mock_cursor.fetchone.side_effect = [mock_owner_check, updated_plan_data]
+
+    token = generate_jwt_token(MOCK_USER_ID)
+    response = client.put(
+        f'/v1/plans/{MOCK_PLAN_ID}',
+        headers={'Authorization': f'Bearer {token}'},
+        json={'name': 'Updated Plan Name'}
+    )
+    assert response.status_code == 200
+    assert response.get_json()['name'] == 'Updated Plan Name'
+
+@patch('engine.app.get_db_connection')
+def test_delete_workout_plan_success(mock_get_db_conn, client):
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_get_db_conn.return_value = mock_conn
+    mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+
+    mock_owner_check = {'user_id': uuid.UUID(MOCK_USER_ID)}
+    mock_cursor.fetchone.return_value = mock_owner_check
+    mock_cursor.rowcount = 1 # Simulate successful deletion
+
+    token = generate_jwt_token(MOCK_USER_ID)
+    response = client.delete(
+        f'/v1/plans/{MOCK_PLAN_ID}',
+        headers={'Authorization': f'Bearer {token}'}
+    )
+    assert response.status_code == 204
+
+# --- Placeholder for Plan Day and Plan Exercise Tests ---
+# These would follow a similar structure to the Workout Plan tests above,
+# mocking appropriate database calls and checking for correct responses and status codes.
+
+# Example for Plan Day creation:
+@patch('engine.app.get_db_connection')
+def test_create_plan_day_success(mock_get_db_conn, client):
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_get_db_conn.return_value = mock_conn
+    mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+
+    # Mock 1: Parent plan ownership check
+    mock_plan_owner = {'user_id': uuid.UUID(MOCK_USER_ID)}
+    # Mock 2: Check for existing day_number (return None for no conflict)
+    # Mock 3: Return value for the new plan day
+    new_plan_day_data = {
+        'id': MOCK_DAY_ID, 'plan_id': MOCK_PLAN_ID, 'day_number': 1, 'name': 'Day 1 - Push'
+    }
+    mock_cursor.fetchone.side_effect = [mock_plan_owner, None, new_plan_day_data]
+
+    token = generate_jwt_token(MOCK_USER_ID)
+    response = client.post(
+        f'/v1/plans/{MOCK_PLAN_ID}/days',
+        headers={'Authorization': f'Bearer {token}'},
+        json={'day_number': 1, 'name': 'Day 1 - Push'}
+    )
+    assert response.status_code == 201
+    response_data = response.get_json()
+    assert response_data['name'] == 'Day 1 - Push'
+    assert response_data['plan_id'] == MOCK_PLAN_ID
+
+@patch('engine.app.get_db_connection')
+def test_create_plan_day_conflict(mock_get_db_conn, client):
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_get_db_conn.return_value = mock_conn
+    mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+
+    mock_plan_owner = {'user_id': uuid.UUID(MOCK_USER_ID)}
+    existing_day_conflict = {'id': str(uuid.uuid4())} # Simulate finding an existing day
+    mock_cursor.fetchone.side_effect = [mock_plan_owner, existing_day_conflict]
+
+    token = generate_jwt_token(MOCK_USER_ID)
+    response = client.post(
+        f'/v1/plans/{MOCK_PLAN_ID}/days',
+        headers={'Authorization': f'Bearer {token}'},
+        json={'day_number': 1, 'name': 'Day 1 - Push'}
+    )
+    assert response.status_code == 409 # Conflict
+    assert 'already exists for this plan' in response.get_json()['error']
+
+
+@patch('engine.app.get_db_connection')
+def test_get_plan_days_success(mock_get_db_conn, client):
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_get_db_conn.return_value = mock_conn
+    mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+
+    # Mock 1: Parent plan ownership check
+    mock_plan_owner = {'user_id': uuid.UUID(MOCK_USER_ID)}
+    # Mock 2: Return list of plan days
+    mock_days_list = [
+        {'id': MOCK_DAY_ID, 'plan_id': MOCK_PLAN_ID, 'day_number': 1, 'name': 'Day 1'},
+        {'id': str(uuid.uuid4()), 'plan_id': MOCK_PLAN_ID, 'day_number': 2, 'name': 'Day 2'}
+    ]
+    mock_cursor.fetchone.return_value = mock_plan_owner # For plan ownership check
+    mock_cursor.fetchall.return_value = mock_days_list # For list of days
+
+    token = generate_jwt_token(MOCK_USER_ID)
+    response = client.get(
+        f'/v1/plans/{MOCK_PLAN_ID}/days',
+        headers={'Authorization': f'Bearer {token}'}
+    )
+    assert response.status_code == 200
+    response_data = response.get_json()
+    assert len(response_data) == 2
+    assert response_data[0]['name'] == 'Day 1'
+
+@patch('engine.app.get_db_connection')
+def test_get_plan_days_plan_not_found(mock_get_db_conn, client):
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_get_db_conn.return_value = mock_conn
+    mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+    mock_cursor.fetchone.return_value = None # Plan not found
+
+    token = generate_jwt_token(MOCK_USER_ID)
+    response = client.get(
+        f'/v1/plans/{str(uuid.uuid4())}/days',
+        headers={'Authorization': f'Bearer {token}'}
+    )
+    assert response.status_code == 404
+    assert 'parent workout plan not found' in response.get_json()['error'].lower()
+
+
+@patch('engine.app.get_db_connection')
+def test_update_plan_day_success(mock_get_db_conn, client):
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_get_db_conn.return_value = mock_conn
+    mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+
+    # Mock 1: fetch day_info (includes plan_owner_id)
+    mock_day_info = {'plan_day_id': MOCK_DAY_ID, 'plan_id': MOCK_PLAN_ID, 'plan_owner_id': uuid.UUID(MOCK_USER_ID)}
+    # Mock 2: day_number conflict check (return None for no conflict)
+    # Mock 3: updated plan day data
+    updated_day_data = {'id': MOCK_DAY_ID, 'name': 'Updated Day Name', 'day_number': 2}
+    mock_cursor.fetchone.side_effect = [mock_day_info, None, updated_day_data]
+
+    token = generate_jwt_token(MOCK_USER_ID)
+    response = client.put(
+        f'/v1/plandays/{MOCK_DAY_ID}',
+        headers={'Authorization': f'Bearer {token}'},
+        json={'name': 'Updated Day Name', 'day_number': 2}
+    )
+    assert response.status_code == 200
+    response_data = response.get_json()
+    assert response_data['name'] == 'Updated Day Name'
+    assert response_data['day_number'] == 2
+
+@patch('engine.app.get_db_connection')
+def test_update_plan_day_forbidden(mock_get_db_conn, client):
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_get_db_conn.return_value = mock_conn
+    mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+
+    mock_day_info_other_owner = {'plan_day_id': MOCK_DAY_ID, 'plan_id': MOCK_PLAN_ID, 'plan_owner_id': uuid.UUID(MOCK_OTHER_USER_ID)}
+    mock_cursor.fetchone.return_value = mock_day_info_other_owner
+
+    token = generate_jwt_token(MOCK_USER_ID) # Current user is MOCK_USER_ID
+    response = client.put(
+        f'/v1/plandays/{MOCK_DAY_ID}',
+        headers={'Authorization': f'Bearer {token}'},
+        json={'name': 'Attempted Update'}
+    )
+    assert response.status_code == 403
+    assert 'you do not own the parent plan' in response.get_json()['error'].lower()
+
+@patch('engine.app.get_db_connection')
+def test_delete_plan_day_success(mock_get_db_conn, client):
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_get_db_conn.return_value = mock_conn
+    mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+
+    mock_day_info = {'plan_owner_id': uuid.UUID(MOCK_USER_ID)}
+    mock_cursor.fetchone.return_value = mock_day_info
+    mock_cursor.rowcount = 1 # Simulate successful deletion
+
+    token = generate_jwt_token(MOCK_USER_ID)
+    response = client.delete(
+        f'/v1/plandays/{MOCK_DAY_ID}',
+        headers={'Authorization': f'Bearer {token}'}
+    )
+    assert response.status_code == 204
+
+@patch('engine.app.get_db_connection')
+def test_delete_plan_day_not_found(mock_get_db_conn, client):
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_get_db_conn.return_value = mock_conn
+    mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+    mock_cursor.fetchone.return_value = None # Day not found
+
+    token = generate_jwt_token(MOCK_USER_ID)
+    response = client.delete(
+        f'/v1/plandays/{str(uuid.uuid4())}',
+        headers={'Authorization': f'Bearer {token}'}
+    )
+    assert response.status_code == 404
+    assert 'plan day not found' in response.get_json()['error'].lower()
+
+
+# Example for Plan Exercise creation:
+@patch('engine.app.get_db_connection')
+def test_create_plan_exercise_success(mock_get_db_conn, client):
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_get_db_conn.return_value = mock_conn
+    mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+
+    # Mock 1: Parent plan day ownership check
+    mock_day_owner = {'plan_owner_id': uuid.UUID(MOCK_USER_ID)}
+    # Mock 2: Exercise ID existence check in 'exercises' table
+    mock_exercise_exists = {'id': MOCK_EXERCISE_ID_DB}
+    # Mock 3: Check for order_index conflict (return None for no conflict)
+    # Mock 4: Return value for the new plan exercise
+    new_plan_exercise_data = {
+        'id': MOCK_PLAN_EXERCISE_ID, 'plan_day_id': MOCK_DAY_ID,
+        'exercise_id': MOCK_EXERCISE_ID_DB, 'order_index': 0, 'sets': 3
+    }
+    mock_cursor.fetchone.side_effect = [mock_day_owner, mock_exercise_exists, None, new_plan_exercise_data]
+
+    token = generate_jwt_token(MOCK_USER_ID)
+    response = client.post(
+        f'/v1/plandays/{MOCK_DAY_ID}/exercises',
+        headers={'Authorization': f'Bearer {token}'},
+        json={'exercise_id': MOCK_EXERCISE_ID_DB, 'order_index': 0, 'sets': 3}
+    )
+    assert response.status_code == 201
+    response_data = response.get_json()
+    assert response_data['exercise_id'] == MOCK_EXERCISE_ID_DB
+    assert response_data['plan_day_id'] == MOCK_DAY_ID
+
+@patch('engine.app.get_db_connection')
+def test_create_plan_exercise_exercise_not_found(mock_get_db_conn, client):
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_get_db_conn.return_value = mock_conn
+    mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+
+    non_existent_exercise_id = str(uuid.uuid4())
+
+    mock_day_owner = {'plan_owner_id': uuid.UUID(MOCK_USER_ID)}
+    mock_exercise_exists_check_returns_none = None # Exercise not found
+    mock_cursor.fetchone.side_effect = [mock_day_owner, mock_exercise_exists_check_returns_none]
+
+    token = generate_jwt_token(MOCK_USER_ID)
+    response = client.post(
+        f'/v1/plandays/{MOCK_DAY_ID}/exercises',
+        headers={'Authorization': f'Bearer {token}'},
+        json={'exercise_id': non_existent_exercise_id, 'order_index': 0, 'sets': 3}
+    )
+    assert response.status_code == 404 # Or 400 depending on how you want to classify this error
+    assert f"exercise with id {non_existent_exercise_id} not found" in response.get_json()['error'].lower()
+
+@patch('engine.app.get_db_connection')
+def test_get_plan_exercises_for_day_success(mock_get_db_conn, client):
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_get_db_conn.return_value = mock_conn
+    mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+
+    mock_day_owner = {'plan_owner_id': uuid.UUID(MOCK_USER_ID)}
+    mock_exercises_list = [
+        {'id': MOCK_PLAN_EXERCISE_ID, 'exercise_name': 'Bench Press', 'order_index': 0},
+        {'id': str(uuid.uuid4()), 'exercise_name': 'Squat', 'order_index': 1}
+    ]
+    mock_cursor.fetchone.return_value = mock_day_owner # For day ownership check
+    mock_cursor.fetchall.return_value = mock_exercises_list # For list of exercises
+
+    token = generate_jwt_token(MOCK_USER_ID)
+    response = client.get(
+        f'/v1/plandays/{MOCK_DAY_ID}/exercises',
+        headers={'Authorization': f'Bearer {token}'}
+    )
+    assert response.status_code == 200
+    response_data = response.get_json()
+    assert len(response_data) == 2
+    assert response_data[0]['exercise_name'] == 'Bench Press'
+
+@patch('engine.app.get_db_connection')
+def test_get_plan_exercises_for_day_day_not_found(mock_get_db_conn, client):
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_get_db_conn.return_value = mock_conn
+    mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+    mock_cursor.fetchone.return_value = None # Day not found for ownership check
+
+    token = generate_jwt_token(MOCK_USER_ID)
+    response = client.get(
+        f'/v1/plandays/{str(uuid.uuid4())}/exercises',
+        headers={'Authorization': f'Bearer {token}'}
+    )
+    assert response.status_code == 404
+    assert 'parent plan day not found' in response.get_json()['error'].lower()
+
+@patch('engine.app.get_db_connection')
+def test_update_plan_exercise_success(mock_get_db_conn, client):
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_get_db_conn.return_value = mock_conn
+    mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+
+    mock_exercise_info = {
+        'plan_exercise_id': MOCK_PLAN_EXERCISE_ID,
+        'plan_day_id': MOCK_DAY_ID,
+        'plan_id': MOCK_PLAN_ID,
+        'plan_owner_id': uuid.UUID(MOCK_USER_ID)
+    }
+    # For the updated exercise data + exercise name lookup
+    updated_exercise_data = {
+        'id': MOCK_PLAN_EXERCISE_ID, 'sets': 5, 'exercise_id': MOCK_EXERCISE_ID_DB
+    }
+    exercise_name_lookup = {'name': 'Test Exercise'}
+
+    # Mock fetchone calls:
+    # 1. exercise_info (owner check)
+    # 2. order_index conflict check (None means no conflict if order_index is changed)
+    # 3. updated exercise data (RETURNING *)
+    # 4. exercise name lookup
+    mock_cursor.fetchone.side_effect = [mock_exercise_info, None, updated_exercise_data, exercise_name_lookup]
+
+    token = generate_jwt_token(MOCK_USER_ID)
+    response = client.put(
+        f'/v1/planexercises/{MOCK_PLAN_EXERCISE_ID}',
+        headers={'Authorization': f'Bearer {token}'},
+        json={'sets': 5, 'order_index': 1} # Example update
+    )
+    assert response.status_code == 200
+    response_data = response.get_json()
+    assert response_data['sets'] == 5
+    assert response_data['exercise_name'] == 'Test Exercise'
+
+
+@patch('engine.app.get_db_connection')
+def test_update_plan_exercise_order_conflict(mock_get_db_conn, client):
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_get_db_conn.return_value = mock_conn
+    mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+
+    mock_exercise_info = {
+        'plan_exercise_id': MOCK_PLAN_EXERCISE_ID,
+        'plan_day_id': MOCK_DAY_ID,
+        'plan_owner_id': uuid.UUID(MOCK_USER_ID)
+    }
+    conflict_check_finds_exercise = {'id': str(uuid.uuid4())} # Different ID, same order_index
+
+    # Simulate ownership check passes, then order_index conflict found
+    mock_cursor.fetchone.side_effect = [mock_exercise_info, conflict_check_finds_exercise]
+
+    token = generate_jwt_token(MOCK_USER_ID)
+    response = client.put(
+        f'/v1/planexercises/{MOCK_PLAN_EXERCISE_ID}',
+        headers={'Authorization': f'Bearer {token}'},
+        json={'order_index': 0} # Attempting to update order_index
+    )
+    assert response.status_code == 409
+    assert 'already exists for this day' in response.get_json()['error']
+
+
+@patch('engine.app.get_db_connection')
+def test_delete_plan_exercise_success(mock_get_db_conn, client):
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_get_db_conn.return_value = mock_conn
+    mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+
+    mock_exercise_info = {'plan_owner_id': uuid.UUID(MOCK_USER_ID)}
+    mock_cursor.fetchone.return_value = mock_exercise_info
+    mock_cursor.rowcount = 1 # Simulate successful deletion
+
+    token = generate_jwt_token(MOCK_USER_ID)
+    response = client.delete(
+        f'/v1/planexercises/{MOCK_PLAN_EXERCISE_ID}',
+        headers={'Authorization': f'Bearer {token}'}
+    )
+    assert response.status_code == 204
+
+@patch('engine.app.get_db_connection')
+def test_delete_plan_exercise_forbidden(mock_get_db_conn, client):
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_get_db_conn.return_value = mock_conn
+    mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+
+    mock_exercise_info_other_owner = {'plan_owner_id': uuid.UUID(MOCK_OTHER_USER_ID)}
+    mock_cursor.fetchone.return_value = mock_exercise_info_other_owner
+
+    token = generate_jwt_token(MOCK_USER_ID)
+    response = client.delete(
+        f'/v1/planexercises/{MOCK_PLAN_EXERCISE_ID}',
+        headers={'Authorization': f'Bearer {token}'}
+    )
+    assert response.status_code == 403
+    assert 'you do not own the parent plan' in response.get_json()['error'].lower()
+
+@patch('engine.app.get_db_connection')
+def test_create_workout_plan_invalid_days_per_week(mock_get_db_conn, client):
+    token = generate_jwt_token(MOCK_USER_ID)
+    response = client.post(
+        f'/v1/users/{MOCK_USER_ID}/plans',
+        headers={'Authorization': f'Bearer {token}'},
+        json={'name': 'Test Plan', 'days_per_week': 8} # Invalid days_per_week
+    )
+    assert response.status_code == 400
+    assert "invalid 'days_per_week'" in response.get_json()['error'].lower()
+    assert "must be between 1 and 7" in response.get_json()['error'].lower()
+
+    response = client.post(
+        f'/v1/users/{MOCK_USER_ID}/plans',
+        headers={'Authorization': f'Bearer {token}'},
+        json={'name': 'Test Plan', 'days_per_week': 0} # Invalid days_per_week
+    )
+    assert response.status_code == 400
+    assert "must be between 1 and 7" in response.get_json()['error'].lower()
+
+
+@patch('engine.app.get_db_connection')
+def test_create_workout_plan_invalid_plan_length_weeks(mock_get_db_conn, client):
+    token = generate_jwt_token(MOCK_USER_ID)
+    response = client.post(
+        f'/v1/users/{MOCK_USER_ID}/plans',
+        headers={'Authorization': f'Bearer {token}'},
+        json={'name': 'Test Plan', 'plan_length_weeks': 0} # Invalid plan_length_weeks
+    )
+    assert response.status_code == 400
+    assert "invalid 'plan_length_weeks'" in response.get_json()['error'].lower()
+    assert "must be at least 1 week" in response.get_json()['error'].lower()
+
+
+@patch('engine.app.get_db_connection')
+def test_update_workout_plan_not_found(mock_get_db_conn, client):
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_get_db_conn.return_value = mock_conn
+    mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+    mock_cursor.fetchone.return_value = None # Plan not found for ownership check
+
+    token = generate_jwt_token(MOCK_USER_ID)
+    response = client.put(
+        f'/v1/plans/{str(uuid.uuid4())}',
+        headers={'Authorization': f'Bearer {token}'},
+        json={'name': 'Updated Name'}
+    )
+    assert response.status_code == 404
+    assert 'workout plan not found' in response.get_json()['error'].lower()
+
+
+@patch('engine.app.get_db_connection')
+def test_update_workout_plan_forbidden(mock_get_db_conn, client):
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_get_db_conn.return_value = mock_conn
+    mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+
+    # Plan exists but belongs to MOCK_OTHER_USER_ID
+    mock_owner_check = {'user_id': uuid.UUID(MOCK_OTHER_USER_ID)}
+    mock_cursor.fetchone.return_value = mock_owner_check
+
+    token = generate_jwt_token(MOCK_USER_ID) # Current user is MOCK_USER_ID
+    response = client.put(
+        f'/v1/plans/{MOCK_PLAN_ID}',
+        headers={'Authorization': f'Bearer {token}'},
+        json={'name': 'Attempted Update by Wrong User'}
+    )
+    assert response.status_code == 403
+    assert 'you do not own this plan' in response.get_json()['error'].lower()
+
+
+@patch('engine.app.get_db_connection')
+def test_delete_workout_plan_not_found(mock_get_db_conn, client):
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_get_db_conn.return_value = mock_conn
+    mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+    mock_cursor.fetchone.return_value = None # Plan not found for ownership check
+
+    token = generate_jwt_token(MOCK_USER_ID)
+    response = client.delete(
+        f'/v1/plans/{str(uuid.uuid4())}',
+        headers={'Authorization': f'Bearer {token}'}
+    )
+    assert response.status_code == 404
+    assert 'workout plan not found' in response.get_json()['error'].lower()
+
+@patch('engine.app.get_db_connection')
+def test_delete_workout_plan_forbidden(mock_get_db_conn, client):
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_get_db_conn.return_value = mock_conn
+    mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+
+    # Plan exists but belongs to MOCK_OTHER_USER_ID
+    mock_owner_check = {'user_id': uuid.UUID(MOCK_OTHER_USER_ID)}
+    mock_cursor.fetchone.return_value = mock_owner_check
+
+    token = generate_jwt_token(MOCK_USER_ID) # Current user is MOCK_USER_ID
+    response = client.delete(
+        f'/v1/plans/{MOCK_PLAN_ID}',
+        headers={'Authorization': f'Bearer {token}'}
+    )
+    assert response.status_code == 403
+    assert 'you do not own this plan' in response.get_json()['error'].lower()
+
+# --- Plan Day Specific Validations ---
+@patch('engine.app.get_db_connection')
+def test_create_plan_day_invalid_day_number(mock_get_db_conn, client):
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_get_db_conn.return_value = mock_conn
+    mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+    mock_plan_owner = {'user_id': uuid.UUID(MOCK_USER_ID)}
+    mock_cursor.fetchone.return_value = mock_plan_owner # Plan ownership check
+
+    token = generate_jwt_token(MOCK_USER_ID)
+    response = client.post(
+        f'/v1/plans/{MOCK_PLAN_ID}/days',
+        headers={'Authorization': f'Bearer {token}'},
+        json={'day_number': -1, 'name': 'Invalid Day'}
+    )
+    assert response.status_code == 400
+    assert "invalid 'day_number'" in response.get_json()['error'].lower()
+    assert "must be a non-negative integer" in response.get_json()['error'].lower()
+
+    response = client.post(
+        f'/v1/plans/{MOCK_PLAN_ID}/days',
+        headers={'Authorization': f'Bearer {token}'},
+        json={'day_number': 'not-an-int', 'name': 'Invalid Day Type'}
+    )
+    assert response.status_code == 400
+    assert "invalid 'day_number'" in response.get_json()['error'].lower()
+
+@patch('engine.app.get_db_connection')
+def test_update_plan_day_invalid_day_number(mock_get_db_conn, client):
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_get_db_conn.return_value = mock_conn
+    mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+
+    mock_day_info = {'plan_day_id': MOCK_DAY_ID, 'plan_id': MOCK_PLAN_ID, 'plan_owner_id': uuid.UUID(MOCK_USER_ID)}
+    mock_cursor.fetchone.return_value = mock_day_info # Ownership check
+
+    token = generate_jwt_token(MOCK_USER_ID)
+    response = client.put(
+        f'/v1/plandays/{MOCK_DAY_ID}',
+        headers={'Authorization': f'Bearer {token}'},
+        json={'day_number': -5}
+    )
+    assert response.status_code == 400
+    assert "invalid 'day_number'" in response.get_json()['error'].lower()
+    assert "must be a non-negative integer" in response.get_json()['error'].lower()
+
+@patch('engine.app.get_db_connection')
+def test_update_plan_day_not_found(mock_get_db_conn, client):
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_get_db_conn.return_value = mock_conn
+    mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+    mock_cursor.fetchone.return_value = None # Day not found for ownership/update
+
+    token = generate_jwt_token(MOCK_USER_ID)
+    response = client.put(
+        f'/v1/plandays/{str(uuid.uuid4())}',
+        headers={'Authorization': f'Bearer {token}'},
+        json={'name': 'Updated Name'}
+    )
+    assert response.status_code == 404
+    assert 'plan day not found' in response.get_json()['error'].lower()
+
+# --- Plan Exercise Specific Validations ---
+
+@patch('engine.app.get_db_connection')
+def test_create_plan_exercise_missing_required_fields(mock_get_db_conn, client):
+    mock_conn = MagicMock() # Simplified, assumes ownership check would pass if it got that far
+    mock_cursor = MagicMock()
+    mock_get_db_conn.return_value = mock_conn
+    mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+    mock_day_owner = {'plan_owner_id': uuid.UUID(MOCK_USER_ID)} # For parent day ownership
+    mock_cursor.fetchone.return_value = mock_day_owner
+
+    token = generate_jwt_token(MOCK_USER_ID)
+
+    # Missing exercise_id
+    response = client.post(
+        f'/v1/plandays/{MOCK_DAY_ID}/exercises',
+        headers={'Authorization': f'Bearer {token}'},
+        json={'order_index': 0, 'sets': 3}
+    )
+    assert response.status_code == 400
+    assert 'missing required field: exercise_id' in response.get_json()['error'].lower()
+
+    # Missing order_index
+    response = client.post(
+        f'/v1/plandays/{MOCK_DAY_ID}/exercises',
+        headers={'Authorization': f'Bearer {token}'},
+        json={'exercise_id': MOCK_EXERCISE_ID_DB, 'sets': 3}
+    )
+    assert response.status_code == 400
+    assert 'missing required field: order_index' in response.get_json()['error'].lower()
+
+    # Missing sets
+    response = client.post(
+        f'/v1/plandays/{MOCK_DAY_ID}/exercises',
+        headers={'Authorization': f'Bearer {token}'},
+        json={'exercise_id': MOCK_EXERCISE_ID_DB, 'order_index': 0}
+    )
+    assert response.status_code == 400
+    assert 'missing required field: sets' in response.get_json()['error'].lower()
+
+@patch('engine.app.get_db_connection')
+def test_create_plan_exercise_invalid_values(mock_get_db_conn, client):
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_get_db_conn.return_value = mock_conn
+    mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+    mock_day_owner = {'plan_owner_id': uuid.UUID(MOCK_USER_ID)}
+    mock_exercise_exists = {'id': MOCK_EXERCISE_ID_DB}
+    # Simulate ownership, exercise existence, no order conflict for these tests
+    mock_cursor.fetchone.side_effect = [mock_day_owner, mock_exercise_exists, None, MagicMock()]
+
+
+    token = generate_jwt_token(MOCK_USER_ID)
+    base_valid_payload = {'exercise_id': MOCK_EXERCISE_ID_DB, 'order_index': 0, 'sets': 3}
+
+    # Invalid order_index
+    payload = {**base_valid_payload, 'order_index': -1}
+    response = client.post(f'/v1/plandays/{MOCK_DAY_ID}/exercises', headers={'Authorization': f'Bearer {token}'}, json=payload)
+    assert response.status_code == 400
+    assert "'order_index' must be non-negative" in response.get_json()['error']
+    mock_cursor.fetchone.side_effect = [mock_day_owner, mock_exercise_exists, None, MagicMock()] # Reset side_effect
+
+    # Invalid sets
+    payload = {**base_valid_payload, 'sets': 0}
+    response = client.post(f'/v1/plandays/{MOCK_DAY_ID}/exercises', headers={'Authorization': f'Bearer {token}'}, json=payload)
+    assert response.status_code == 400
+    assert "'sets' must be at least 1" in response.get_json()['error']
+    mock_cursor.fetchone.side_effect = [mock_day_owner, mock_exercise_exists, None, MagicMock()]
+
+    # Invalid rep_range_low
+    payload = {**base_valid_payload, 'rep_range_low': -1}
+    response = client.post(f'/v1/plandays/{MOCK_DAY_ID}/exercises', headers={'Authorization': f'Bearer {token}'}, json=payload)
+    assert response.status_code == 400
+    assert "'rep_range_low' must be non-negative" in response.get_json()['error']
+    mock_cursor.fetchone.side_effect = [mock_day_owner, mock_exercise_exists, None, MagicMock()]
+
+    # Invalid rest_seconds
+    payload = {**base_valid_payload, 'rest_seconds': -10}
+    response = client.post(f'/v1/plandays/{MOCK_DAY_ID}/exercises', headers={'Authorization': f'Bearer {token}'}, json=payload)
+    assert response.status_code == 400
+    assert "'rest_seconds' must be non-negative" in response.get_json()['error']
+
+
+@patch('engine.app.get_db_connection')
+def test_update_plan_exercise_invalid_values(mock_get_db_conn, client):
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_get_db_conn.return_value = mock_conn
+    mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+
+    mock_exercise_info = {
+        'plan_exercise_id': MOCK_PLAN_EXERCISE_ID, 'plan_day_id': MOCK_DAY_ID,
+        'plan_id': MOCK_PLAN_ID, 'plan_owner_id': uuid.UUID(MOCK_USER_ID)
+    }
+    # Simulate ownership check pass, no conflict for valid updates
+    mock_cursor.fetchone.side_effect = lambda q,v: mock_exercise_info if "pe.id = %s" in q else \
+                                                (None if "order_index = %s" in q else MagicMock())
+
+
+    token = generate_jwt_token(MOCK_USER_ID)
+
+    # Invalid sets
+    response = client.put(f'/v1/planexercises/{MOCK_PLAN_EXERCISE_ID}', headers={'Authorization': f'Bearer {token}'}, json={'sets': 0})
+    assert response.status_code == 400
+    assert "'sets' must be at least 1" in response.get_json()['error']
+    mock_cursor.fetchone.side_effect = lambda q,v: mock_exercise_info if "pe.id = %s" in q else \
+                                        (None if "order_index = %s" in q else MagicMock())
+
+    # Invalid rep_range_high
+    response = client.put(f'/v1/planexercises/{MOCK_PLAN_EXERCISE_ID}', headers={'Authorization': f'Bearer {token}'}, json={'rep_range_high': -2})
+    assert response.status_code == 400
+    assert "'rep_range_high' must be non-negative" in response.get_json()['error']
+
+@patch('engine.app.get_db_connection')
+def test_update_plan_exercise_not_found(mock_get_db_conn, client):
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_get_db_conn.return_value = mock_conn
+    mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+    mock_cursor.fetchone.return_value = None # Exercise not found for ownership/update check
+
+    token = generate_jwt_token(MOCK_USER_ID)
+    response = client.put(
+        f'/v1/planexercises/{str(uuid.uuid4())}',
+        headers={'Authorization': f'Bearer {token}'},
+        json={'sets': 5}
+    )
+    assert response.status_code == 404
+    assert 'plan exercise not found' in response.get_json()['error'].lower()
+
+
+# TODO: Add more tests for PUT, DELETE, GET (list/specific) for PlanDay and PlanExercise -> Mostly done for PlanExercise now
+# TODO: Add tests for various error conditions (400, 401, 403, 404, 409) for all endpoints. -> Covered many, can always add more specific field validations
+# TODO: Consider testing specific validation logic (e.g., days_per_week range). -> Partially done for workout plan create
+
+if __name__ == '__main__':
+    # This allows running pytest directly on this file if needed, though typically run via `pytest` command
+    pytest.main()


### PR DESCRIPTION
This commit introduces the backend APIs for the Plan Builder and Analytics Dashboard as per Phase 3 requirements.

Plan Builder API:
- Added CRUD endpoints for workout plans, plan days, and plan exercises under `/v1/users/<user_id>/plans`, `/v1/plans/<plan_id>`, `/v1/plandays/<day_id>`, and `/v1/planexercises/<plan_exercise_id>`.
- Endpoints support creation, retrieval (single and list), update, and deletion of these entities.
- Implemented ownership checks using JWT authentication to ensure you can only manage your own data.
- Included comprehensive unit tests for all Plan Builder API endpoints, covering various scenarios including success cases, authorization, error handling, and input validation.

Analytics Dashboard API:
- Added a `GET /v1/users/<user_id>/exercises/<exercise_id>/plateau-analysis` endpoint.
- This endpoint fetches historical performance data (e1RM) for you and an exercise.
- Integrates with `engine/progression.py` to detect plateaus (stagnation/regression).
- Suggests a deload protocol if a plateau is identified, considering your current fatigue for the relevant muscle group.
- Handles cases of insufficient data for analysis.
- Added comprehensive unit tests for the analytics endpoint, mocking external dependencies and covering various outcomes and error conditions.

All new endpoints are integrated into the existing Flask application in `engine/app.py` and follow established project conventions for database access, authentication, and error handling.