### PR TITLE
[P1-BE-xyz] remove env var fallbacks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# GymGenius environment variables
+
+# Flask JWT secret key
+JWT_SECRET_KEY=
+
+# Optional complete database URL e.g. postgres://user:pass@host:5432/dbname
+DATABASE_URL=
+
+# Or specify individual Postgres parameters
+POSTGRES_DB=
+POSTGRES_USER=
+POSTGRES_PASSWORD=
+POSTGRES_HOST=
+POSTGRES_PORT=
+

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ license:     MIT
 git clone https://github.com/your-org/gymgenius.git
 cd gymgenius
 
+# 1.1 Configure environment variables
+cp .env.example .env  # then fill in JWT and Postgres settings
+
 # 2 Spin up full stack (API + DB + ML worker + Web)
 make dev            # alias for `docker compose -f docker-compose.dev.yml up --build`
 
@@ -56,6 +59,13 @@ To process background training jobs separately, run the worker:
 ```bash
 python -m engine.worker
 ```
+
+### Environment Variables
+
+The API requires several settings to run. Copy `.env.example` to `.env` and provide values for:
+
+- `JWT_SECRET_KEY`
+- `DATABASE_URL` *(optional)* or `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_HOST`, `POSTGRES_PORT`
 
 ### Project Structure
 

--- a/engine/app.py
+++ b/engine/app.py
@@ -22,7 +22,7 @@ app = Flask(__name__)
 
 # --- JWT Configuration ---
 # In a real app, use a strong, randomly generated key stored securely (e.g., env variable)
-app.config['JWT_SECRET_KEY'] = os.getenv('JWT_SECRET_KEY', 'your-super-secret-jwt-key-please-change')
+app.config['JWT_SECRET_KEY'] = os.getenv('JWT_SECRET_KEY')
 app.config['JWT_ACCESS_TOKEN_EXPIRES'] = timedelta(hours=1) # Access token valid for 1 hour
 # Consider adding JWT_REFRESH_TOKEN_EXPIRES if implementing refresh tokens
 
@@ -55,11 +55,11 @@ def get_db_connection():
     # Original fallback to individual POSTGRES_* variables
     try:
         conn = psycopg2.connect(
-            dbname=os.getenv("POSTGRES_DB", "gymgenius_dev"),
-            user=os.getenv("POSTGRES_USER", "gymgenius"),
-            password=os.getenv("POSTGRES_PASSWORD", "secret"),
-            host=os.getenv("POSTGRES_HOST", "db"), # In CI, this will be 'postgres' or 'localhost' for service container
-            port=os.getenv("POSTGRES_PORT", "5432")
+            dbname=os.getenv("POSTGRES_DB"),
+            user=os.getenv("POSTGRES_USER"),
+            password=os.getenv("POSTGRES_PASSWORD"),
+            host=os.getenv("POSTGRES_HOST"),  # In CI, this will be 'postgres' or 'localhost' for service container
+            port=os.getenv("POSTGRES_PORT")
         )
         # logger.info("Connected to database using POSTGRES_* environment variables.") # Optional
         return conn


### PR DESCRIPTION
## Summary
- require JWT secret and Postgres settings from environment
- document required `.env` variables
- add `.env.example` template for local setup

## Testing
- `make lint` *(fails: F841, E701 etc.)*
- `make test` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684f16ace9588329af3a91ed4d7f3e1f