### PR TITLE
[P1-BE-001] add connection pooling

### DIFF
--- a/engine/tasks.py
+++ b/engine/tasks.py
@@ -5,7 +5,7 @@ import psycopg2.extras
 from redis import Redis
 from rq import Queue
 
-from .app import get_db_connection
+from .app import get_db_connection, release_db_connection
 
 logger = logging.getLogger(__name__)
 
@@ -38,4 +38,4 @@ def nightly_user_model_update(task_name="nightly_user_model_update", force_run=F
         logger.error("Database error during nightly update: %s", e)
     finally:
         if conn:
-            conn.close()
+            release_db_connection(conn)

--- a/tests/test_analytics_api.py
+++ b/tests/test_analytics_api.py
@@ -1,5 +1,4 @@
 import pytest
-import json
 import uuid
 import datetime
 from unittest.mock import patch, MagicMock, ANY # ANY is useful for some mock assertions
@@ -244,7 +243,7 @@ def test_get_plateau_analysis_exercise_no_main_target_muscle_group(mock_get_db_c
         headers={'Authorization': f'Bearer {token}'}
     )
     assert response.status_code == 404
-    assert f"is missing 'main_target_muscle_group'" in response.get_json()['error']
+    assert "is missing 'main_target_muscle_group'" in response.get_json()['error']
 
 @patch('engine.app.get_db_connection')
 def test_get_plateau_analysis_db_error_exercise_fetch(mock_get_db_conn, client):

--- a/tests/test_plan_builder_api.py
+++ b/tests/test_plan_builder_api.py
@@ -1,5 +1,4 @@
 import pytest
-import json
 import uuid
 from unittest.mock import patch, MagicMock
 


### PR DESCRIPTION
## Summary
- create a global connection pool using `psycopg2.pool`
- return pooled connections instead of closing them
- update tasks job to release connections
- clean up lint warnings in tests

## Testing
- `make lint`
- `make test` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684f16ad140c8329aada0d660f13389e