### PR TITLE
[P3-BE-003] add analytics endpoints

### DIFF
--- a/tests/test_plan_builder_api.py
+++ b/tests/test_plan_builder_api.py
@@ -1,5 +1,4 @@
 import pytest
-import json
 import uuid
 from unittest.mock import patch, MagicMock
 


### PR DESCRIPTION
## Summary
- implement analytics routes: 1RM evolution, volume heatmap & key metrics
- add unit tests for new analytics routes
- clean up unused imports and fix lint issues

## Testing
- `make lint`
- `make test` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684f16b4235c8329829430f9fd403223