### PR TITLE
[P4-FE-002] Integrate Plan Builder API calls

### DIFF
--- a/engine/app.py
+++ b/engine/app.py
@@ -1414,7 +1414,6 @@ def update_plan_day(day_id):
                 logger.warning(f"Forbidden attempt to update plan day {day_id} by user {g.current_user_id}")
                 return jsonify(error="Forbidden. You do not own the parent plan of this day."), 403
 
-            allowed_fields = {'name': str, 'day_number': int}
             update_fields_parts = []
             update_values = []
 
@@ -1543,8 +1542,10 @@ def create_plan_exercise(day_id):
         exercise_id = str(uuid.UUID(data['exercise_id'])) # Validate UUID
         order_index = int(data['order_index'])
         sets = int(data['sets'])
-        if order_index < 0: raise ValueError("'order_index' must be non-negative.")
-        if sets < 1: raise ValueError("'sets' must be at least 1.")
+        if order_index < 0:
+            raise ValueError("'order_index' must be non-negative.")
+        if sets < 1:
+            raise ValueError("'sets' must be at least 1.")
     except (ValueError, TypeError) as e:
         return jsonify(error=f"Invalid data type or value for required fields: {e}"), 400
 

--- a/tests/test_analytics_api.py
+++ b/tests/test_analytics_api.py
@@ -1,5 +1,4 @@
 import pytest
-import json
 import uuid
 import datetime
 from unittest.mock import patch, MagicMock, ANY # ANY is useful for some mock assertions
@@ -244,7 +243,7 @@ def test_get_plateau_analysis_exercise_no_main_target_muscle_group(mock_get_db_c
         headers={'Authorization': f'Bearer {token}'}
     )
     assert response.status_code == 404
-    assert f"is missing 'main_target_muscle_group'" in response.get_json()['error']
+    assert "is missing 'main_target_muscle_group'" in response.get_json()['error']
 
 @patch('engine.app.get_db_connection')
 def test_get_plateau_analysis_db_error_exercise_fetch(mock_get_db_conn, client):

--- a/tests/test_plan_builder_api.py
+++ b/tests/test_plan_builder_api.py
@@ -1,5 +1,4 @@
 import pytest
-import json
 import uuid
 from unittest.mock import patch, MagicMock
 

--- a/webapp/js/plan_builder.js
+++ b/webapp/js/plan_builder.js
@@ -3,18 +3,17 @@
 document.addEventListener('DOMContentLoaded', () => {
     console.log('Plan Builder script loaded');
 
-    // Mock list of exercises
-    const mockExercises = [
-        { id: 1, name: 'Push-ups', type: 'Strength', muscleGroup: 'Chest' },
-        { id: 2, name: 'Squats', type: 'Strength', muscleGroup: 'Legs' },
-        { id: 3, name: 'Jumping Jacks', type: 'Cardio', muscleGroup: 'Full Body' }, // Could contribute to overall activity but not specific muscle volume
-        { id: 4, name: 'Plank', type: 'Core', muscleGroup: 'Core' }, // Standardized to 'Core'
-        { id: 5, name: 'Bicep Curls', type: 'Strength', muscleGroup: 'Arms' }, // Could be 'Biceps' or 'Arms'
-        { id: 6, name: 'Lunges', type: 'Strength', muscleGroup: 'Legs' },
-        { id: 7, name: 'Bent Over Rows', type: 'Strength', muscleGroup: 'Back' },
-        { id: 8, name: 'Overhead Press', type: 'Strength', muscleGroup: 'Shoulders' },
-        { id: 9, name: 'Tricep Dips', type: 'Strength', muscleGroup: 'Arms' }, // Could be 'Triceps' or 'Arms'
-    ];
+    // Fetch exercises from API
+    function fetchExercises() {
+        return fetch(`${API_BASE_URL}/v1/exercises`, {
+            headers: getAuthHeaders()
+        })
+            .then(resp => resp.json())
+            .catch(err => {
+                console.error('Failed to fetch exercises:', err);
+                return [];
+            });
+    }
 
     const exerciseListElement = document.getElementById('exercise-list');
     const dropZoneElement = document.getElementById('drop-zone');
@@ -28,6 +27,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const planTemplatesListElement = document.getElementById('plan-templates-list');
 
     let currentPlan = []; // Will now store exercises with potential sets/reps
+    let availableExercises = [];
 
     // --- Predefined Plan Templates ---
     const planTemplates = [
@@ -60,7 +60,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     ];
 
-    // Function to display exercises from mockExercises
+    // Function to display exercises fetched from API
     function displayExercises(exercises) {
         if (!exerciseListElement) return;
         exerciseListElement.innerHTML = ''; // Clear existing list
@@ -118,11 +118,11 @@ document.addEventListener('DOMContentLoaded', () => {
             return;
         }
 
-        const exerciseFromMock = mockExercises.find(ex => ex.id.toString() === exerciseId);
-        if (exerciseFromMock) {
-            // Add default sets/reps when adding from mock list
+        const exerciseFromList = availableExercises.find(ex => ex.id.toString() === exerciseId);
+        if (exerciseFromList) {
+            // Add default sets/reps when adding from list
             const exerciseToAdd = {
-                ...exerciseFromMock,
+                ...exerciseFromList,
                 sets: 3, // Default sets
                 reps: 10 // Default reps
             };
@@ -308,7 +308,10 @@ document.addEventListener('DOMContentLoaded', () => {
     if (clearPlanButton) clearPlanButton.addEventListener('click', clearPlan);
 
     // Initial setup
-    displayExercises(mockExercises);
+    fetchExercises().then(exercises => {
+        availableExercises = exercises;
+        displayExercises(exercises);
+    });
     displayPlanTemplates(); // Display templates on load
     renderPlan(); // To show the initial "Drag and drop" message
     calculatePlanDetails();

--- a/webapp/tests/plan_builder_fetch.test.js
+++ b/webapp/tests/plan_builder_fetch.test.js
@@ -1,0 +1,45 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const { JSDOM } = require('jsdom');
+
+test('plan builder fetches exercises with auth header', async () => {
+  const appCode = fs.readFileSync(path.resolve(__dirname, '../js/app.js'), 'utf8');
+  const pbCode = fs.readFileSync(path.resolve(__dirname, '../js/plan_builder.js'), 'utf8');
+
+  const dom = new JSDOM(`<!DOCTYPE html>
+    <ul id="exercise-list"></ul>
+    <div id="drop-zone"></div>
+    <ul id="volume-list"></ul>
+    <ul id="frequency-list"></ul>
+    <button id="save-plan"></button>
+    <button id="load-plan"></button>
+    <button id="clear-plan"></button>
+    <ul id="plan-templates-list"></ul>`, { url: 'http://localhost/plan_builder.html' });
+
+  global.window = dom.window;
+  global.document = dom.window.document;
+  global.localStorage = dom.window.localStorage;
+  global.navigator = dom.window.navigator;
+
+  const context = {
+    window: dom.window,
+    document: dom.window.document,
+    localStorage: dom.window.localStorage,
+    navigator: dom.window.navigator,
+    console,
+    fetch: jest.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve([]) })
+  };
+
+  vm.createContext(context);
+  vm.runInContext(appCode, context);
+  context.storeToken('tok');
+  vm.runInContext(pbCode, context);
+
+  dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
+
+  await context.fetch.mock.results[0].value;
+  expect(context.fetch).toHaveBeenCalled();
+  expect(context.fetch.mock.calls[0][0]).toContain('/v1/exercises');
+  expect(context.fetch.mock.calls[0][1].headers.Authorization).toBe('Bearer tok');
+});


### PR DESCRIPTION
## Summary
- fetch exercises via API in Plan Builder
- ensure requests include auth token
- add test verifying fetch logic
- fix ruff issues in backend tests

## Testing
- `make lint`
- `make test` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684f16b611ac8329a5c9ba2a7ea997a7