### PR TITLE
[P3-BE-006] compute plan metrics

### DIFF
--- a/database/create_schema.py
+++ b/database/create_schema.py
@@ -123,6 +123,13 @@ CREATE TABLE IF NOT EXISTS plan_exercises (
     UNIQUE(plan_day_id, order_index)
 );
 
+-- Plan Metrics Table to store aggregated plan volume and frequency
+CREATE TABLE IF NOT EXISTS plan_metrics (
+    plan_id UUID PRIMARY KEY REFERENCES workout_plans(id) ON DELETE CASCADE,
+    total_volume INTEGER DEFAULT 0,
+    muscle_group_frequency JSONB DEFAULT '{}'
+);
+
 -- Workouts Table (Log of actual workout sessions)
 CREATE TABLE IF NOT EXISTS workouts (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -195,6 +202,7 @@ CREATE INDEX IF NOT EXISTS idx_workout_plans_user_id ON workout_plans(user_id);
 CREATE INDEX IF NOT EXISTS idx_plan_days_plan_id ON plan_days(plan_id);
 CREATE INDEX IF NOT EXISTS idx_plan_exercises_plan_day_id ON plan_exercises(plan_day_id);
 CREATE INDEX IF NOT EXISTS idx_plan_exercises_exercise_id ON plan_exercises(exercise_id);
+CREATE INDEX IF NOT EXISTS idx_plan_metrics_plan_id ON plan_metrics(plan_id);
 CREATE INDEX IF NOT EXISTS idx_workouts_user_id_started_at ON workouts(user_id, started_at DESC);
 CREATE INDEX IF NOT EXISTS idx_workout_sets_workout_id ON workout_sets(workout_id);
 CREATE INDEX IF NOT EXISTS idx_workout_sets_exercise_id_completed_at ON workout_sets(exercise_id, completed_at DESC);

--- a/engine/app.py
+++ b/engine/app.py
@@ -1044,8 +1044,53 @@ def create_workout_plan(user_id):
                 (plan_id, str(user_id), plan_name, days_per_week, plan_length_weeks, goal_focus)
             )
             new_plan = cur.fetchone()
+
+            # --- Calculate volume and frequency if plan details provided ---
+            total_volume = 0
+            freq_tracker = {}
+            days_payload = data.get('days', []) or []
+
+            for day in days_payload:
+                day_number = day.get('day_number')
+                day_name = day.get('name')
+                day_id = str(uuid.uuid4())
+                if day_number is not None:
+                    cur.execute(
+                        "INSERT INTO plan_days (id, plan_id, day_number, name) VALUES (%s, %s, %s, %s);",
+                        (day_id, plan_id, day_number, day_name),
+                    )
+
+                for ex in day.get('exercises', []) or []:
+                    exercise_id = ex.get('exercise_id')
+                    sets = int(ex.get('sets', 0))
+                    if not exercise_id:
+                        continue
+                    cur.execute(
+                        "SELECT main_target_muscle_group FROM exercises WHERE id = %s;",
+                        (exercise_id,),
+                    )
+                    ex_details = cur.fetchone()
+                    mg = ex_details.get('main_target_muscle_group') if ex_details else None
+                    cur.execute(
+                        "INSERT INTO plan_exercises (id, plan_day_id, exercise_id, order_index, sets) VALUES (%s, %s, %s, %s, %s);",
+                        (str(uuid.uuid4()), day_id, exercise_id, ex.get('order_index', 0), sets),
+                    )
+                    total_volume += sets
+                    if mg and day_number is not None:
+                        freq_tracker.setdefault(mg, set()).add(day_number)
+
+            freq_counts = {k: len(v) for k, v in freq_tracker.items()}
+            cur.execute(
+                "INSERT INTO plan_metrics (plan_id, total_volume, muscle_group_frequency) VALUES (%s, %s, %s);",
+                (plan_id, total_volume, psycopg2.extras.Json(freq_counts)),
+            )
+
             conn.commit()
-            logger.info(f"Workout plan '{plan_name}' (ID: {plan_id}) created successfully for user: {user_id}")
+            new_plan['total_volume'] = total_volume
+            new_plan['muscle_group_frequency'] = freq_counts
+            logger.info(
+                f"Workout plan '{plan_name}' (ID: {plan_id}) created successfully for user: {user_id}"
+            )
             return jsonify(new_plan), 201
 
     except psycopg2.Error as e:
@@ -1414,7 +1459,6 @@ def update_plan_day(day_id):
                 logger.warning(f"Forbidden attempt to update plan day {day_id} by user {g.current_user_id}")
                 return jsonify(error="Forbidden. You do not own the parent plan of this day."), 403
 
-            allowed_fields = {'name': str, 'day_number': int}
             update_fields_parts = []
             update_values = []
 
@@ -1543,8 +1587,10 @@ def create_plan_exercise(day_id):
         exercise_id = str(uuid.UUID(data['exercise_id'])) # Validate UUID
         order_index = int(data['order_index'])
         sets = int(data['sets'])
-        if order_index < 0: raise ValueError("'order_index' must be non-negative.")
-        if sets < 1: raise ValueError("'sets' must be at least 1.")
+        if order_index < 0:
+            raise ValueError("'order_index' must be non-negative.")
+        if sets < 1:
+            raise ValueError("'sets' must be at least 1.")
     except (ValueError, TypeError) as e:
         return jsonify(error=f"Invalid data type or value for required fields: {e}"), 400
 

--- a/tests/test_analytics_api.py
+++ b/tests/test_analytics_api.py
@@ -1,5 +1,4 @@
 import pytest
-import json
 import uuid
 import datetime
 from unittest.mock import patch, MagicMock, ANY # ANY is useful for some mock assertions
@@ -244,7 +243,7 @@ def test_get_plateau_analysis_exercise_no_main_target_muscle_group(mock_get_db_c
         headers={'Authorization': f'Bearer {token}'}
     )
     assert response.status_code == 404
-    assert f"is missing 'main_target_muscle_group'" in response.get_json()['error']
+    assert "is missing 'main_target_muscle_group'" in response.get_json()['error']
 
 @patch('engine.app.get_db_connection')
 def test_get_plateau_analysis_db_error_exercise_fetch(mock_get_db_conn, client):

--- a/tests/test_plan_builder_api.py
+++ b/tests/test_plan_builder_api.py
@@ -1,5 +1,4 @@
 import pytest
-import json
 import uuid
 from unittest.mock import patch, MagicMock
 
@@ -65,20 +64,39 @@ def test_create_workout_plan_success(mock_get_db_conn, client):
         'created_at': '2023-01-01T10:00:00Z',
         'updated_at': '2023-01-01T10:00:00Z'
     }
-    mock_cursor.fetchone.return_value = mock_plan_data
+    mock_cursor.fetchone.side_effect = [
+        mock_plan_data,
+        {'main_target_muscle_group': 'chest'}
+    ]
 
     token = generate_jwt_token(MOCK_USER_ID)
     response = client.post(
         f'/v1/users/{MOCK_USER_ID}/plans',
         headers={'Authorization': f'Bearer {token}'},
-        json={'name': 'My New Plan', 'days_per_week': 3, 'plan_length_weeks': 4, 'goal_focus': 'hypertrophy'}
+        json={
+            'name': 'My New Plan',
+            'days_per_week': 3,
+            'plan_length_weeks': 4,
+            'goal_focus': 'hypertrophy',
+            'days': [
+                {
+                    'day_number': 1,
+                    'name': 'Day 1',
+                    'exercises': [
+                        {'exercise_id': MOCK_EXERCISE_ID_DB, 'sets': 5}
+                    ]
+                }
+            ]
+        }
     )
 
     assert response.status_code == 201
     response_data = response.get_json()
     assert response_data['name'] == 'My New Plan'
     assert response_data['user_id'] == MOCK_USER_ID
-    mock_cursor.execute.assert_called_once() # Simplified check, could be more specific
+    assert response_data['total_volume'] == 5
+    assert response_data['muscle_group_frequency']['chest'] == 1
+    assert any('plan_metrics' in str(c.args[0]) for c in mock_cursor.execute.call_args_list)
 
 @patch('engine.app.get_db_connection')
 def test_create_workout_plan_unauthorized_no_token(mock_get_db_conn, client):


### PR DESCRIPTION
## Summary
- track total plan volume and frequency in `plan_metrics`
- compute metrics when creating workout plans
- verify metrics stored in API tests

## Testing
- `make lint`
- `make test-engine` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684f1a4e027083299371c9d8052e908c