### PR TITLE
[P3-BE-006] Add psycopg2 driver

### DIFF
--- a/engine/requirements.txt
+++ b/engine/requirements.txt
@@ -6,3 +6,4 @@ PyJWT
 
 rq
 redis
+psycopg2-binary


### PR DESCRIPTION
## Summary
- add `psycopg2-binary` to engine requirements for PostgreSQL connectivity

## Testing
- `make lint` *(fails: `ruff` errors in existing code)*
- `make test` *(fails: missing Flask dependency due to lack of internet access)*

------
https://chatgpt.com/codex/tasks/task_e_6851a73ca2c08329955dbe7c77a8958e