### PR TITLE
[P1-BE-XXX] Enable pgcrypto extension

### DIFF
--- a/database/create_schema.py
+++ b/database/create_schema.py
@@ -49,6 +49,7 @@ else:
 SQL_COMMANDS = """
 -- Enable UUID generation
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
 
 -- Users Table
 CREATE TABLE IF NOT EXISTS users (


### PR DESCRIPTION
## Summary
- enable `pgcrypto` extension in the schema creation script for `gen_random_uuid`

## Testing
- `make lint` *(fails: engine lint errors)*
- `make test` *(fails: missing `flask` dependency)*

------
https://chatgpt.com/codex/tasks/task_e_6851a73d30fc832981569bb7f61362c9