### PR TITLE
feat: Enhance frontend usability for plans and equipment

### DIFF
--- a/webapp/index.html
+++ b/webapp/index.html
@@ -35,5 +35,6 @@
     <script src="js/config.js"></script>
     <script src="js/onboarding.js"></script>
     <script src="js/app.js"></script>
+    <script src="js/profile.js"></script>
 </body>
 </html>

--- a/webapp/js/app.js
+++ b/webapp/js/app.js
@@ -284,7 +284,7 @@ document.addEventListener('DOMContentLoaded', () => {
         '#logset': LogSetPage,
         '#exercises': ExerciseListPage, // Added ExerciseListPage
         '#rir-weight-input': RirWeightInputPage,
-        // '#profile': ProfilePage, // Example for later
+        '#profile': ProfilePage,
     };
 
     function navigate() {
@@ -783,6 +783,7 @@ function updateFooterNav() {
         footerNav.innerHTML = `
             <a href="#exercises">Exercises</a>
             <a href="#workouts">My Workouts</a>
+            <a href="#profile">Profile</a>
             <a href="#rir-weight-input">RIR/Weight Calc</a>
             <a id="feedback-link" target="_blank">Beta Feedback</a>
             <a href="#" id="logout-link">Logout</a>
@@ -810,6 +811,48 @@ function NotFoundPage() {
     const page = document.createElement('div');
     page.className = 'page active';
     page.innerHTML = '<h2>404 - Page Not Found</h2>';
+    return page;
+}
+
+// --- Profile Page ---
+function ProfilePage() {
+    const page = document.createElement('div');
+    page.className = 'page active';
+    page.innerHTML = `
+        <h2>User Profile</h2>
+        <section id="equipment-management">
+            <h3>My Equipment</h3>
+            <div id="equipment-message" style="display:none;"></div>
+            <form id="equipment-form">
+                <h4>Weight Plates</h4>
+                <div id="plate-selection">
+                    <!-- Plate toggles/checkboxes will be dynamically added here by profile.js -->
+                    <p>Loading plate options...</p>
+                </div>
+                <p>Default Barbell Weight (kg): <input type="number" id="barbell-weight-kg" value="20" step="0.5"></p>
+
+                <h4>Dumbbells</h4>
+                <div>
+                    <label for="dumbbell-type">Type:</label>
+                    <select id="dumbbell-type">
+                        <option value="none">None</option>
+                        <option value="fixed">Fixed Weight</option>
+                        <option value="adjustable">Adjustable</option>
+                    </select>
+                </div>
+                <div id="fixed-dumbbells-section" style="display:none;">
+                    <label for="fixed-dumbbell-weights">Available Fixed Dumbbell Weights (kg, comma-separated):</label>
+                    <input type="text" id="fixed-dumbbell-weights" placeholder="e.g., 5, 7.5, 10, 12.5, 15">
+                </div>
+                <div id="adjustable-dumbbells-section" style="display:none;">
+                    <label for="adjustable-dumbbell-max-weight">Max Weight per Adjustable Dumbbell (kg):</label>
+                    <input type="number" id="adjustable-dumbbell-max-weight" step="0.5">
+                </div>
+
+                <button type="submit">Save Equipment</button>
+            </form>
+        </section>
+    `;
     return page;
 }
 

--- a/webapp/js/plan_builder.js
+++ b/webapp/js/plan_builder.js
@@ -50,8 +50,11 @@ document.addEventListener('DOMContentLoaded', () => {
     const volumeListElement = document.getElementById('volume-list');
     const frequencyListElement = document.getElementById('frequency-list');
     const savePlanButton = document.getElementById('save-plan');
-    const loadPlansButton = document.getElementById('load-plans-btn'); // Changed ID for clarity
+    const loadPlansButton = document.getElementById('load-plan');
     const clearPlanButton = document.getElementById('clear-plan');
+    const planSaveFeedbackDiv = document.getElementById('plan-save-feedback');
+    const feedbackTotalVolumeSpan = document.getElementById('feedback-total-volume');
+    const feedbackFrequencyListUl = document.getElementById('feedback-frequency-list');
     const userPlansListElement = document.getElementById('user-plans-list');
     const planNameInput = document.getElementById('plan-name'); // Assuming an input field for plan name
 
@@ -139,6 +142,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // --- Plan Management Functions ---
     function addExerciseToPlan(exercise) {
+        if (planSaveFeedbackDiv) {
+            planSaveFeedbackDiv.style.display = 'none';
+            if (feedbackTotalVolumeSpan) feedbackTotalVolumeSpan.textContent = 'N/A';
+            if (feedbackFrequencyListUl) feedbackFrequencyListUl.innerHTML = '';
+        }
         // Ensure exercise has default sets/reps if not provided (e.g. when dragged)
         const exerciseToAdd = {
             ...exercise,
@@ -152,6 +160,11 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     function removeExerciseFromPlan(exerciseIdToRemove) {
+        if (planSaveFeedbackDiv) {
+            planSaveFeedbackDiv.style.display = 'none';
+            if (feedbackTotalVolumeSpan) feedbackTotalVolumeSpan.textContent = 'N/A';
+            if (feedbackFrequencyListUl) feedbackFrequencyListUl.innerHTML = '';
+        }
         const idToRemove = exerciseIdToRemove.toString(); // Ensure comparison with string IDs from dataset
         currentPlanExercises = currentPlanExercises.filter(ex => ex.id.toString() !== idToRemove);
         renderPlan();
@@ -246,6 +259,11 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     function handleSetRepChange(event) {
+        if (planSaveFeedbackDiv) {
+            planSaveFeedbackDiv.style.display = 'none';
+            if (feedbackTotalVolumeSpan) feedbackTotalVolumeSpan.textContent = 'N/A';
+            if (feedbackFrequencyListUl) feedbackFrequencyListUl.innerHTML = '';
+        }
         const index = parseInt(event.target.dataset.index, 10);
         const property = event.target.classList.contains('plan-exercise-sets') ? 'sets' : 'reps';
         let value = event.target.value;
@@ -320,8 +338,28 @@ document.addEventListener('DOMContentLoaded', () => {
             }
 
             const savedPlan = await response.json();
-            alert(`Plan ${method === 'POST' ? 'saved' : 'updated'} successfully!`);
+            // alert(`Plan ${method === 'POST' ? 'saved' : 'updated'} successfully!`);
             console.log('Saved/Updated plan:', savedPlan);
+
+            if (feedbackTotalVolumeSpan) feedbackTotalVolumeSpan.textContent = savedPlan.total_volume || 'N/A';
+            if (feedbackFrequencyListUl) feedbackFrequencyListUl.innerHTML = '';
+
+            if (savedPlan.muscle_group_frequency && typeof savedPlan.muscle_group_frequency === 'object') {
+                if (Object.keys(savedPlan.muscle_group_frequency).length > 0) {
+                    for (const muscleGroup in savedPlan.muscle_group_frequency) {
+                        const listItem = document.createElement('li');
+                        listItem.textContent = `${muscleGroup}: ${savedPlan.muscle_group_frequency[muscleGroup]} session(s)`;
+                        if (feedbackFrequencyListUl) feedbackFrequencyListUl.appendChild(listItem);
+                    }
+                } else {
+                    if (feedbackFrequencyListUl) feedbackFrequencyListUl.innerHTML = '<li>No specific muscle group frequency calculated.</li>';
+                }
+            } else {
+                if (feedbackFrequencyListUl) feedbackFrequencyListUl.innerHTML = '<li>Frequency data not available.</li>';
+            }
+
+            if (planSaveFeedbackDiv) planSaveFeedbackDiv.style.display = 'block';
+            alert('Plan saved!'); // Or remove if UI feedback is sufficient
 
             if (method === 'POST' && savedPlan.id) { // If new plan saved
                 currentLoadedPlanId = savedPlan.id;
@@ -333,6 +371,7 @@ document.addEventListener('DOMContentLoaded', () => {
         } catch (error) {
             console.error('Error saving plan:', error);
             alert(`Error saving plan: ${error.message}`);
+            if (planSaveFeedbackDiv) planSaveFeedbackDiv.style.display = 'none';
         }
     }
 
@@ -486,6 +525,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
 
     function clearPlan() {
+        if (planSaveFeedbackDiv) {
+            planSaveFeedbackDiv.style.display = 'none';
+            if (feedbackTotalVolumeSpan) feedbackTotalVolumeSpan.textContent = 'N/A';
+            if (feedbackFrequencyListUl) feedbackFrequencyListUl.innerHTML = '';
+        }
         currentPlanExercises = [];
         currentLoadedPlanId = null;
         currentLoadedPlanName = "My New Plan";
@@ -506,7 +550,7 @@ document.addEventListener('DOMContentLoaded', () => {
         dropZoneElement.addEventListener('drop', handleDrop);
     }
     if (savePlanButton) savePlanButton.addEventListener('click', savePlan);
-    if (loadPlansButton) loadPlansButton.addEventListener('click', loadUserPlans); // Changed
+    if (loadPlansButton) loadPlansButton.addEventListener('click', loadUserPlans);
     if (clearPlanButton) clearPlanButton.addEventListener('click', clearPlan);
 
     // Initial setup

--- a/webapp/js/profile.js
+++ b/webapp/js/profile.js
@@ -1,0 +1,229 @@
+document.addEventListener('DOMContentLoaded', () => {
+    // --- Constants and Initial Setup ---
+    const METRIC_PLATES = [25, 20, 15, 10, 5, 2.5, 1.25];
+    const IMPERIAL_PLATES = [45, 35, 25, 10, 5, 2.5]; // Assuming common imperial plates
+
+    const equipmentForm = document.getElementById('equipment-form');
+    const plateSelectionDiv = document.getElementById('plate-selection');
+    const dumbbellTypeSelect = document.getElementById('dumbbell-type');
+    const fixedDumbbellsSection = document.getElementById('fixed-dumbbells-section');
+    const adjustableDumbbellsSection = document.getElementById('adjustable-dumbbells-section');
+    const barbellWeightInput = document.getElementById('barbell-weight-kg');
+    const fixedDumbbellWeightsInput = document.getElementById('fixed-dumbbell-weights');
+    const adjustableDumbbellMaxWeightInput = document.getElementById('adjustable-dumbbell-max-weight');
+    const equipmentMessageDiv = document.getElementById('equipment-message');
+
+    // Assumed to be globally available from app.js
+    // const currentUserId = /* ... */;
+    // const API_BASE_URL = /* ... */;
+    // const getAuthHeaders = /* ... */;
+
+    let currentUserProfileData = null; // To store fetched profile data for PATCH updates
+
+    // --- Dynamic Plate Options Rendering ---
+    function renderPlateOptions(plates, selectedPlates = []) {
+        if (!plateSelectionDiv) {
+            console.error('plateSelectionDiv not found');
+            return;
+        }
+        plateSelectionDiv.innerHTML = ''; // Clear existing options
+        plates.forEach(p => {
+            const label = document.createElement('label');
+            const checkbox = document.createElement('input');
+            checkbox.type = 'checkbox';
+            checkbox.name = 'plate';
+            checkbox.value = p;
+            if (selectedPlates.includes(p)) {
+                checkbox.checked = true;
+            }
+            label.appendChild(checkbox);
+            label.appendChild(document.createTextNode(` ${p}`));
+            plateSelectionDiv.appendChild(label);
+            plateSelectionDiv.appendChild(document.createElement('br')); // For better spacing
+        });
+    }
+
+    // --- Dumbbell Type Visibility Toggle ---
+    if (dumbbellTypeSelect) {
+        dumbbellTypeSelect.addEventListener('change', () => {
+            const type = dumbbellTypeSelect.value;
+            if (fixedDumbbellsSection) fixedDumbbellsSection.style.display = type === 'fixed' ? 'block' : 'none';
+            if (adjustableDumbbellsSection) adjustableDumbbellsSection.style.display = type === 'adjustable' ? 'block' : 'none';
+        });
+    } else {
+        console.error('dumbbellTypeSelect not found');
+    }
+
+    // --- Fetch User Profile and Populate Form ---
+    async function loadUserProfile() {
+        if (!currentUserId) {
+            displayMessage('User ID not found. Please log in.', true);
+            return;
+        }
+        if (!API_BASE_URL || !getAuthHeaders) {
+            displayMessage('API configuration missing.', true);
+            console.error('API_BASE_URL or getAuthHeaders is not defined');
+            return;
+        }
+
+        displayMessage('Loading profile...', false);
+
+        try {
+            const response = await fetch(`${API_BASE_URL}/v1/users/${currentUserId}/profile`, {
+                method: 'GET',
+                headers: getAuthHeaders()
+            });
+
+            const data = await response.json();
+
+            if (response.ok) {
+                currentUserProfileData = data; // Store for potential PATCH later
+                const profileData = data; // Use 'data' directly for this function scope
+                const unitSystem = profileData.unit_system || 'metric'; // Default to metric
+
+                let platesToRender = METRIC_PLATES;
+                let selectedPlatesKey = 'plates_kg';
+                if (unitSystem === 'imperial') {
+                    platesToRender = IMPERIAL_PLATES;
+                    selectedPlatesKey = 'plates_lbs';
+                }
+
+                const availablePlatesData = profileData.available_plates || {};
+
+                renderPlateOptions(platesToRender, availablePlatesData[selectedPlatesKey] || []);
+
+                if (barbellWeightInput) {
+                    barbellWeightInput.value = availablePlatesData.barbell_weight_kg || 20;
+                }
+
+                if (dumbbellTypeSelect) {
+                    const dumbbellData = availablePlatesData.dumbbells || {};
+                    dumbbellTypeSelect.value = dumbbellData.type || 'none';
+                    // Trigger change to update visibility
+                    dumbbellTypeSelect.dispatchEvent(new Event('change'));
+
+                    if (fixedDumbbellWeightsInput && dumbbellData.type === 'fixed') {
+                        fixedDumbbellWeightsInput.value = (dumbbellData.available_weights_kg || []).join(', ');
+                    }
+                    if (adjustableDumbbellMaxWeightInput && dumbbellData.type === 'adjustable') {
+                        adjustableDumbbellMaxWeightInput.value = dumbbellData.max_weight_kg || '';
+                    }
+                }
+                displayMessage('Profile loaded.', false, true); // Clear after a delay
+            } else {
+                displayMessage(data.error || 'Failed to load profile.', true);
+            }
+        } catch (error) {
+            console.error('Error loading profile:', error);
+            displayMessage('Error loading profile. Check console for details.', true);
+        }
+    }
+
+    // --- Handle Form Submission (Save Equipment) ---
+    if (equipmentForm) {
+        equipmentForm.addEventListener('submit', async (event) => {
+            event.preventDefault();
+            if (!currentUserId) {
+                displayMessage('User ID not found. Cannot save.', true);
+                return;
+            }
+
+            displayMessage('Saving equipment...', false);
+
+            const selectedPlateElements = plateSelectionDiv.querySelectorAll('input[name="plate"]:checked');
+            const selectedPlates = Array.from(selectedPlateElements).map(el => parseFloat(el.value));
+
+            // For now, assume metric is used for saving. Unit system handling can be expanded.
+            const availablePlates = {
+                plate_units: 'kg', // Or determine from a user setting if available
+                plates_kg: selectedPlates,
+                barbell_weight_kg: parseFloat(barbellWeightInput.value) || 20,
+                dumbbells: {
+                    type: dumbbellTypeSelect.value,
+                }
+            };
+
+            if (dumbbellTypeSelect.value === 'fixed') {
+                availablePlates.dumbbells.available_weights_kg = fixedDumbbellWeightsInput.value
+                    .split(',')
+                    .map(s => s.trim())
+                    .filter(s => s)
+                    .map(s => parseFloat(s));
+            } else if (dumbbellTypeSelect.value === 'adjustable') {
+                availablePlates.dumbbells.max_weight_kg = parseFloat(adjustableDumbbellMaxWeightInput.value) || null;
+            }
+
+            // Constructing the update payload.
+            // Option 1: Send only the 'available_plates' field (assuming backend handles partial PATCH or this specific structure)
+            const profileUpdateData = { available_plates: availablePlates };
+
+            // Option 2: Send the whole profile object back with 'available_plates' modified (safer for strict PUT/PATCH)
+            // This requires `currentUserProfileData` to be populated from `loadUserProfile`.
+            // let fullProfileUpdate = { ...currentUserProfileData, available_plates: availablePlates };
+            // delete fullProfileUpdate.id; // Remove fields that shouldn't be sent back, like user_id or email if not allowed
+            // delete fullProfileUpdate.email;
+            // delete fullProfileUpdate.created_at;
+            // delete fullProfileUpdate.updated_at;
+            // const profileUpdateData = fullProfileUpdate;
+
+
+            try {
+                const response = await fetch(`${API_BASE_URL}/v1/users/${currentUserId}/profile`, {
+                    method: 'PUT', // Or PATCH, depending on API design for partial updates
+                    headers: getAuthHeaders(),
+                    body: JSON.stringify(profileUpdateData)
+                });
+
+                const data = await response.json();
+
+                if (response.ok) {
+                    displayMessage('Equipment saved successfully!', false, true);
+                    currentUserProfileData = data; // Update local cache of profile
+                } else {
+                    displayMessage(data.error || 'Failed to save equipment.', true);
+                }
+            } catch (error) {
+                console.error('Error saving equipment:', error);
+                displayMessage('Error saving equipment. Check console for details.', true);
+            }
+        });
+    } else {
+        console.error('equipmentForm not found');
+    }
+
+    // --- Helper to display messages ---
+    function displayMessage(message, isError = false, autoClear = false) {
+        if (!equipmentMessageDiv) return;
+        equipmentMessageDiv.textContent = message;
+        equipmentMessageDiv.style.color = isError ? 'red' : 'green';
+        equipmentMessageDiv.style.display = 'block';
+
+        if (autoClear) {
+            setTimeout(() => {
+                equipmentMessageDiv.style.display = 'none';
+                equipmentMessageDiv.textContent = '';
+            }, 3000);
+        }
+    }
+
+    // --- Initial Load ---
+    // Make sure currentUserId is available before loading.
+    // This might require waiting for app.js to fully initialize currentUserId.
+    // For simplicity, we assume it's available or will be shortly.
+    // A more robust solution might use a custom event or a check loop.
+    if (typeof currentUserId !== 'undefined' && currentUserId !== null) {
+        loadUserProfile();
+    } else {
+        // Attempt to load after a short delay, in case app.js is still initializing
+        setTimeout(() => {
+            if (typeof currentUserId !== 'undefined' && currentUserId !== null) {
+                loadUserProfile();
+            } else {
+                console.warn('currentUserId not available after delay. Profile will not be loaded automatically.');
+                // displayMessage('Could not load user profile: User not identified.', true);
+                // Optionally, hide the form or parts of it if user ID is essential
+                 if (plateSelectionDiv) plateSelectionDiv.innerHTML = '<p>Please log in to manage your equipment.</p>';
+            }
+        }, 500);
+    }
+});

--- a/webapp/plan_builder.html
+++ b/webapp/plan_builder.html
@@ -50,12 +50,27 @@
                         <!-- Frequency data will be populated here by JS -->
                     </ul>
                 </div>
+                <div id="plan-save-feedback" style="display:none; margin-top: 15px; padding: 10px; border: 1px solid #ccc; background-color: #f9f9f9;">
+                    <h4>Plan Save Confirmation:</h4>
+                    <p><strong>Total Volume:</strong> <span id="feedback-total-volume">N/A</span> sets</p>
+                    <p><strong>Muscle Group Frequency:</strong></p>
+                    <ul id="feedback-frequency-list">
+                        <!-- Frequency data will be populated here by JS -->
+                    </ul>
+                </div>
             </section>
             <section id="plan-controls">
                 <h2>Plan Management</h2>
                 <button id="save-plan">Save Plan</button>
             <button id="load-plan">Load Plan</button>
             <button id="clear-plan">Clear Plan</button>
+        </section>
+        <section id="user-plans-section">
+            <h2>Your Saved Plans</h2>
+            <ul id="user-plans-list">
+                <!-- User's saved plans will be listed here by JS -->
+                <li>Click "Load Plan" to fetch your plans.</li>
+            </ul>
         </section>
     </main>
     <footer>


### PR DESCRIPTION
This commit introduces major improvements to the user experience for managing workout equipment and interacting with workout plans.

Key changes include:

1.  **Equipment Management (Profile Page):**
    *   A new User Profile page (`#profile`) allows you to manage your available equipment.
    *   You can specify owned weight plates (common denominations), barbell weight, and dumbbell types (fixed weights or adjustable).
    *   This information is fetched from and saved to your profile via the `/v1/users/{user_id}/profile` API.

2.  **Plan Saving Feedback:**
    *   The "Save Plan" functionality in the Plan Builder now provides immediate, detailed feedback.
    *   Upon successfully saving a plan, the UI displays the `total_volume` and `muscle_group_frequency` (e.g., "Chest: 2 sessions") as returned by the backend.
    *   This feedback is cleared if the plan is subsequently modified.

3.  **Load Plan Interface:**
    *   Corrected the event listener for the "Load Plan" button.
    *   Added a dedicated section in the Plan Builder UI to display the list of your saved workout plans, fetched from the backend.
    *   You can load a selected plan into the builder or delete it.

These changes significantly improve the quality and intuitiveness of the plan creation and equipment setup features, addressing the core requirements of the issue.