### PR TITLE
Replace deprecated hex colors

### DIFF
--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -44,7 +44,7 @@ Consistent typography enhances readability and user experience.
 
 *   **Body Text (`p`, general text)**: `1em`, `400` weight, `#1d1d1f` color, `line-height: 1.6`.
 *   **Labels (`label`)**: `1em` (or `0.95em` in specific contexts like profile forms), `500` weight, `#1d1d1f` color, `margin-bottom: 8px`.
-*   **Links (`a`)**: Inherit font size, `400` or `500` weight, `#1d1d1f` color. Hover: `#0056b3`. No text decoration by default, underline on hover for some links (e.g., `.form-link`).
+*   **Links (`a`)**: Inherit font size, `400` or `500` weight, `#1d1d1f` color. Hover: `#515154`. No text decoration by default, underline on hover for some links (e.g., `.form-link`).
 *   **Small Text (`small`)**: `0.85em` - `0.9em`.
 
 ## 4. Spacing
@@ -191,10 +191,10 @@ Used for dashboard sections, plan builder panels, profile sections, workout exec
 ### Navigation
 
 *   **Header/Footer Links (`header nav a`, `footer nav a`)**:
-    *   `color: #007bff;`
+    *   `color: #1d1d1f;`
     *   `text-decoration: none;`
     *   `padding: 0.5em 1em;`
-    *   Hover: `color: #0056b3;`. Dashboard header links may have `text-decoration: underline;` on hover.
+    *   Hover: `color: #515154;`. Dashboard header links may have `text-decoration: underline;` on hover.
 *   **Hamburger Menu (`.hamburger-menu .bar`)**: `background-color: #2c3e50;`.
 
 ### Lists

--- a/engine/templates/share_error.html
+++ b/engine/templates/share_error.html
@@ -30,11 +30,11 @@
         }
         p {
             font-size: 1.1em;
-            color: #555;
+            color: #515154;
             margin-bottom: 25px;
         }
         a {
-            color: #007bff;
+            color: #1d1d1f;
             text-decoration: none;
             font-weight: 500;
         }
@@ -44,7 +44,7 @@
         .footer {
             margin-top: 30px;
             font-size: 0.9em;
-            color: #777;
+            color: #86868b;
         }
     </style>
 </head>

--- a/engine/templates/share_workout.html
+++ b/engine/templates/share_workout.html
@@ -28,7 +28,7 @@
             font-size: 1.8em;
         }
         h2 {
-            color: #555;
+            color: #515154;
             margin-top: 30px;
             margin-bottom: 10px;
             font-size: 1.4em;
@@ -37,7 +37,7 @@
             margin-bottom: 10px;
         }
         strong {
-            color: #555;
+            color: #515154;
         }
         table {
             border-collapse: collapse;
@@ -65,12 +65,12 @@
             margin-top: 30px;
             text-align: center;
             font-size: 0.9em;
-            color: #777;
+            color: #86868b;
         }
         .empty-state {
             text-align: center;
             padding: 20px;
-            color: #777;
+            color: #86868b;
         }
     </style>
 </head>

--- a/webapp/css/dashboard.css
+++ b/webapp/css/dashboard.css
@@ -9,8 +9,8 @@
     box-shadow: 0 2px 4px rgba(0,0,0,0.05);
     text-align: left;
    Global h1 in header: font-size: 1.75em; font-weight: 600; margin: 0;
-   Global nav a: color: #007bff; text-decoration: none; padding: 0.5em 1em; margin: 0 0.5em;
-   Global nav a:hover: color: #0056b3;
+   Global nav a: color: #1d1d1f; text-decoration: none; padding: 0.5em 1em; margin: 0 0.5em;
+   Global nav a:hover: color: #515154;
 */
 
 /* Dashboard header might have its nav items styled slightly differently or additional items */
@@ -23,7 +23,7 @@ header nav {
 
 /* Override for dashboard nav links if global style isn't quite right for this context */
 header nav a {
-  /* color: #007bff; */ /* Inherited */
+  /* color: #1d1d1f; */ /* Inherited */
   /* text-decoration: none; */ /* Inherited */
   margin-right: 20px; /* Specific to dashboard.css, global is margin: 0 0.5em; */
   font-size: 1em; /* Global is based on 0.5em padding, this is explicit font-size */
@@ -32,7 +32,7 @@ header nav a {
 }
 header nav a:hover {
   /* text-decoration: underline; */ /* Global is 'none', dashboard.css adds underline */
-  /* color: #0056b3; */ /* Inherited */
+  /* color: #515154; */ /* Inherited */
   text-decoration: underline; /* Explicitly keep underline for dashboard nav hover */
 }
 
@@ -469,12 +469,12 @@ footer {
 }
 
 .plateau-notification strong {
-  /* color: #555; */ /* Inherits from .plateau-notification color now */
+  /* color: #515154; */ /* Inherits from .plateau-notification color now */
 }
 
 .plateau-notification small {
   font-size: 0.85em;
-  /* color: #777; */ /* Inherits */
+  /* color: #86868b; */ /* Inherits */
 }
 
 /* Removing custom button style, will use .button-secondary or .button-sm */

--- a/webapp/js/dashboard_charts.js
+++ b/webapp/js/dashboard_charts.js
@@ -203,7 +203,7 @@ function render1RMEvolutionChart(exerciseId, exerciseData) {
                     },
                     ticks: {
                         font: { family: '"Segoe UI", Roboto, Helvetica, Arial, sans-serif', size: 12 },
-                        color: '#6c757d'
+                        color: '#515154'
                     },
                     grid: {
                         borderColor: '#dee2e6',
@@ -220,7 +220,7 @@ function render1RMEvolutionChart(exerciseId, exerciseData) {
                     beginAtZero: false,
                     ticks: {
                         font: { family: '"Segoe UI", Roboto, Helvetica, Arial, sans-serif', size: 12 },
-                        color: '#6c757d',
+                        color: '#515154',
                         padding: 5
                     },
                     grid: {
@@ -560,7 +560,7 @@ function renderVolumeDistributionChart(processedChartData, annotationCfg) {
                     stacked: true, // Enable stacking
                     ticks: {
                         font: { family: '"Segoe UI", Roboto, Helvetica, Arial, sans-serif', size: 12 },
-                        color: '#6c757d'
+                        color: '#515154'
                     },
                     grid: {
                         borderColor: '#dee2e6',
@@ -578,7 +578,7 @@ function renderVolumeDistributionChart(processedChartData, annotationCfg) {
                     stacked: true, // Enable stacking
                     ticks: {
                         font: { family: '"Segoe UI", Roboto, Helvetica, Arial, sans-serif', size: 12 },
-                        color: '#6c757d',
+                        color: '#515154',
                         padding: 5
                     },
                     grid: {
@@ -816,7 +816,7 @@ function renderMTITrendsChart(mtiData) {
                     },
                     ticks: {
                         font: { family: '"Segoe UI", Roboto, Helvetica, Arial, sans-serif', size: 12 },
-                        color: '#6c757d'
+                        color: '#515154'
                     },
                     grid: {
                         borderColor: '#dee2e6',
@@ -833,7 +833,7 @@ function renderMTITrendsChart(mtiData) {
                     beginAtZero: false, // Or true if MTI score starts from 0
                     ticks: {
                         font: { family: '"Segoe UI", Roboto, Helvetica, Arial, sans-serif', size: 12 },
-                        color: '#6c757d',
+                        color: '#515154',
                         padding: 5
                     },
                     grid: {
@@ -1238,7 +1238,7 @@ function renderRecoveryPatternsHeatmap(exerciseName, processedMatrixData) {
                         font: { family: '"Segoe UI", Roboto, Helvetica, Arial, sans-serif', size: 14, weight: '500' }, color: '#495057'
                     },
                     ticks: {
-                        font: { family: '"Segoe UI", Roboto, Helvetica, Arial, sans-serif', size: 12 }, color: '#6c757d',
+                        font: { family: '"Segoe UI", Roboto, Helvetica, Arial, sans-serif', size: 12 }, color: '#515154',
                     },
                     grid: { display: false }
                 },
@@ -1251,7 +1251,7 @@ function renderRecoveryPatternsHeatmap(exerciseName, processedMatrixData) {
                         font: { family: '"Segoe UI", Roboto, Helvetica, Arial, sans-serif', size: 14, weight: '500' }, color: '#495057'
                     },
                     ticks: {
-                        font: { family: '"Segoe UI", Roboto, Helvetica, Arial, sans-serif', size: 12 }, color: '#6c757d',
+                        font: { family: '"Segoe UI", Roboto, Helvetica, Arial, sans-serif', size: 12 }, color: '#515154',
                     },
                     grid: { display: false }
                 }


### PR DESCRIPTION
## Summary
- update link colors in style guide
- switch dashboard nav comments to new palette
- update grey placeholders for notifications
- use medium gray for chart axes
- replace deprecated hex codes in sharing templates

## Testing
- `make lint` *(fails: ruff found errors)*
- `make test` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685515af2ce08329a655a178f6d4e160